### PR TITLE
Updating LangChain4J CDI Liberty example to Microprofile 7.1 

### DIFF
--- a/examples/liberty-car-booking/src/main/liberty/config/server.xml
+++ b/examples/liberty-car-booking/src/main/liberty/config/server.xml
@@ -2,11 +2,11 @@
     <featureManager>
     	<!-- Eclipse Microprofile 6.1 -->
     	<!-- See details here: https://openliberty.io/docs/ref/feature/#microProfile-6.1.html -->
-    	<feature>microProfile-6.1</feature>
+    	<feature>microProfile-7.1</feature>
     	
-		<!-- microProfile 6.1 Feature contains the following features below:
-	    	<feature>mpTelemetry-2.0</feature>
-	    	<feature>mpFaultTolerance-4.0</feature>
+		<!-- microProfile 7.1 Feature contains the following features below:
+	    	<feature>mpTelemetry-2.1</feature>
+	    	<feature>mpFaultTolerance-4.1</feature>
 	    	<feature>mpMetrics-5.1</feature>
     	-->
     </featureManager>


### PR DESCRIPTION
This resolves the issue where MP Telemetry is not being injected.