### PR TITLE
Workaround runtime error WELD-001334, by defining a custom producer in glassfish-car-booking

### DIFF
--- a/examples/glassfish-car-booking/config/llm-config.properties
+++ b/examples/glassfish-car-booking/config/llm-config.properties
@@ -12,6 +12,9 @@ dev.langchain4j.plugin.docRagRetriever.config.embeddingStore=lookup:@default
 dev.langchain4j.plugin.docRagRetriever.config.embeddingModel=lookup:@default
 dev.langchain4j.plugin.docRagRetriever.config.maxResults=3
 dev.langchain4j.plugin.docRagRetriever.config.minScore=0.6
+# Workaround for https://github.com/langchain4j/langchain4j-cdi/issues/144
+# dev.langchain4j.cdi.plugin.CommonLLMPluginCreator looks for ProducerFunction defined by the key defined_bean_producer
+dev.langchain4j.plugin.docRagRetriever.defined_bean_producer=docRagRetrieverProducer
 
 # Chat Memory used by ChatAiService class
 dev.langchain4j.plugin.chat-ai-service-memory.class=dev.langchain4j.memory.chat.MessageWindowChatMemory

--- a/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/DummyLLConfig.java
+++ b/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/DummyLLConfig.java
@@ -1,8 +1,19 @@
 package dev.langchain4j.cdi.example.booking;
 
 import dev.langchain4j.cdi.core.config.spi.LLMConfig;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.util.TypeLiteral;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+
 import java.io.FileReader;
 import java.io.IOException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -14,6 +25,94 @@ public class DummyLLConfig extends LLMConfig {
     public void init() {
         try (FileReader fileReader = new FileReader(System.getProperty("llmconfigfile"))) {
             properties.load(fileReader);
+
+            // Workaround for https://github.com/langchain4j/langchain4j-cdi/issues/144
+            // CommonLLMPluginCreator calls llmConfig.getBeanPropertyValue(beanName, LLMConfig.PRODUCER, ProducerFunction.class)
+            // to find out a ProducerFunction. If found, invokes this ProducerFunction to build the bean
+            String beanProducer =getValue(PREFIX + ".docRagRetriever.defined_bean_producer");
+            if (beanProducer == null) {
+                return;
+            }
+            registerProducer(beanProducer, (Instance<Object> ctx, String beanName, LLMConfig cfg) -> {
+
+                // Resolve using BeanManager
+                BeanManager bm = CDI.current().getBeanManager();
+
+                // Resolve EmbeddingModel
+                EmbeddingModel model;
+                {
+                    java.util.Set<Bean<?>> beans = bm.getBeans(EmbeddingModel.class);
+                    if (beans == null || beans.isEmpty()) {
+                        beans = bm.getBeans(EmbeddingModel.class);
+                    }
+                    Bean<?> bean = bm.resolve(beans);
+                    var creationalContext = bm.createCreationalContext(bean);
+                    model = (EmbeddingModel) bm.getReference(bean, EmbeddingModel.class, creationalContext);
+                }
+
+                // Resolve EmbeddingStore<TextSegment>
+                EmbeddingStore<TextSegment> store;
+                {
+                    java.lang.reflect.Type storeType = new TypeLiteral<EmbeddingStore<TextSegment>>() {}.getType();
+                    java.util.Set<Bean<?>> beans = bm.getBeans(storeType);
+                    if (beans == null || beans.isEmpty()) {
+                        beans = bm.getBeans(storeType);
+                    }
+                    Bean<?> bean = bm.resolve(beans);
+                    var creationalContext = bm.createCreationalContext(bean);
+                    @SuppressWarnings("unchecked")
+                    EmbeddingStore<TextSegment> resolved = (EmbeddingStore<TextSegment>) bm.getReference(bean, storeType, creationalContext);
+                    store = resolved;
+                }
+
+                try {
+                    Class<?> retrieverClass = Class.forName("dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever");
+                    Object builder = retrieverClass.getMethod("builder").invoke(null);
+                    Class<?> builderClass = builder.getClass();
+
+                    builderClass.getMethod("embeddingModel", EmbeddingModel.class).invoke(builder, model);
+                    Class<?> embStoreIface = Class.forName("dev.langchain4j.store.embedding.EmbeddingStore");
+                    builderClass.getMethod("embeddingStore", embStoreIface).invoke(builder, store);
+
+                    try {
+                        String maxResults = cfg.getBeanPropertyValue("docRagRetriever", "config.maxResults");
+                        if (maxResults != null && !maxResults.isBlank()) {
+                            Method method = Arrays.stream(builderClass.getMethods())
+                                    .filter(m -> m.getName().equals("maxResults"))
+                                    .filter(m -> m.getParameterCount() == 1)
+                                    .filter(m -> m.getParameterTypes()[0] == int.class
+                                            || m.getParameterTypes()[0] == Integer.class)
+                                    .findFirst()
+                                    .orElseThrow(() -> new NoSuchMethodException("No suitable maxResults method"));
+
+                            int value = Integer.parseInt(maxResults.trim());
+                            method.invoke(builder, value);
+                        }
+                    } catch (Exception ignoreExc) {
+                        // Ignore exception
+                    }
+                    try {
+                        String minScore = cfg.getBeanPropertyValue("docRagRetriever", "config.minScore");
+                        if (minScore != null && !minScore.isBlank()) {
+                            Method method = Arrays.stream(builderClass.getMethods())
+                                    .filter(m -> m.getName().equals("minScore"))
+                                    .filter(m -> m.getParameterCount() == 1)
+                                    .filter(m -> m.getParameterTypes()[0] == double.class
+                                            || m.getParameterTypes()[0] == Double.class)
+                                    .findFirst()
+                                    .orElseThrow(() -> new NoSuchMethodException("No suitable minScore method"));
+
+                            int value = Integer.parseInt(minScore.trim());
+                            method.invoke(builder, value);
+                        }
+                    } catch (Exception ignoreExc) {
+                        // Ignore exception
+                    }
+                    return builderClass.getMethod("build").invoke(builder);
+                } catch (Exception e) {
+                    throw new RuntimeException("Failed to build EmbeddingStoreContentRetriever via reflection", e);
+                }
+            });
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
This is a workaround for the issue https://github.com/langchain4j/langchain4j-cdi/issues/144. The change makes use of the configuration defined_bean_producer supported by CommonLLMPluginCreator, to define a custom producer.

The sample examples/payara-car-booking doesn't contain LLMConfig implementation, might require some other change.