### PR TITLE
Add ExpressionResolver SPI with Jakarta EL and MicroProfile Config support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,263 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+LangChain4j CDI is a CDI (Contexts and Dependency Injection) extension that integrates the LangChain4j AI framework with Jakarta EE and Eclipse MicroProfile applications. It enables developers to inject AI services into CDI-managed beans with enterprise features like fault tolerance, telemetry, and external configuration.
+
+## Build System
+
+**CRITICAL: Use `mvn` command only** - Never use `./mvnw` or `mvnw` wrappers, as per user's global preferences.
+
+**Java Version Requirements:**
+- Runtime target: Java 17
+- Build requirement: Java 21+ (some integration tests require Java 21+)
+
+**Payara Exclusion:** Always exclude the Payara example module due to network connectivity issues:
+```bash
+-pl '!examples/payara-car-booking'
+```
+
+### Essential Build Commands
+
+Build and compile (skip tests):
+```bash
+mvn clean install -DskipTests -pl '!examples/payara-car-booking'
+```
+
+Full build with tests:
+```bash
+mvn clean verify -pl '!examples/payara-car-booking'
+```
+
+Run unit tests only (exclude integration tests):
+```bash
+mvn test -pl '!examples/payara-car-booking,!langchain4j-cdi-integration-tests'
+```
+
+Run all tests including integration:
+```bash
+mvn test -pl '!examples/payara-car-booking'
+```
+
+Check and apply code formatting:
+```bash
+mvn spotless:check -pl '!examples/payara-car-booking'
+mvn spotless:apply -pl '!examples/payara-car-booking'
+```
+
+## Module Architecture
+
+### Core Modules
+
+**langchain4j-cdi-core**: Foundation of the CDI integration
+- `@RegisterAIService` stereotype annotation for declaring AI service interfaces
+- `CommonAIServiceCreator` utility for building AI service proxies from CDI beans
+- `LLMConfig` and `LLMConfigProvider` configuration API and SPI
+- `CommonLLMPluginCreator` for creating LangChain4j components via reflection
+
+**langchain4j-cdi-portable-ext**: Portable CDI extension for runtime service registration
+- Works with traditional Jakarta EE servers (WildFly, GlassFish, Liberty, Payara)
+- `LangChain4JAIServicePortableExtension` processes `@RegisterAIService` annotations
+- `LangChain4JPluginsPortableExtension` handles plugin bean registration
+
+**langchain4j-cdi-build-compatible-ext**: Build-time CDI extension
+- For ahead-of-time compilation frameworks (Quarkus, Helidon)
+- Static analysis and bean registration at build time
+
+**langchain4j-cdi-el**: Jakarta EL expression resolver
+- Resolves `#{...}` expressions in annotation string attributes at runtime
+- Uses `jakarta.el.ELProcessor`; wires CDI bean resolution when CDI is active
+- Discovered automatically via `ServiceLoader` when on the classpath
+- Requires a Jakarta EL implementation at runtime (e.g. `org.glassfish.expressly:expressly`)
+
+### MicroProfile Integration Modules (langchain4j-cdi-mp)
+
+**langchain4j-cdi-config**: MicroProfile Config integration
+- External configuration via `microprofile-config.properties`
+- Property-based configuration for chat models, embedding models, memory, etc.
+- Pattern: `langchain4j.<component>.<name>.<property>`
+
+**langchain4j-cdi-fault-tolerance**: MicroProfile Fault Tolerance integration
+- `@Retry`, `@Timeout`, `@CircuitBreaker`, `@Fallback` support on AI service methods
+- Resilient AI service calls with automatic retries and fallback mechanisms
+
+**langchain4j-cdi-telemetry**: MicroProfile Telemetry integration
+- OpenTelemetry-based observability for AI service calls
+- Automatic metrics for request/response times, success/failure rates, token usage
+
+## Key Extension Points
+
+### Registering AI Services
+
+AI services are declared using the `@RegisterAIService` annotation:
+
+```java
+@RegisterAIService(
+    chatModelName = "#default",           // or specific bean name
+    toolProviderName = "myTools",          // or use tools = { MyTool.class }
+    chatMemoryName = "chat-memory",
+    contentRetrieverName = "retriever"     // mutually exclusive with retrievalAugmentorName
+)
+public interface ChatAiService {
+    String chat(String userMessage);
+}
+```
+
+**Name Resolution:**
+- `"#default"` = use the default CDI bean of that type
+- Empty/blank = ignore this dependency
+- Specific name = use the named bean
+- `"${property.key}"` = resolved via MicroProfile Config (requires `langchain4j-cdi-config`)
+- `"#{el.expression}"` = evaluated as Jakarta EL (requires `langchain4j-cdi-el`)
+
+Resolution is performed by the `ExpressionResolver` SPI (`dev.langchain4j.cdi.spi.ExpressionResolver`) in `CdiLookupHelper.resolveExpression()`. Implementations are discovered via `ServiceLoader` and applied as a pipeline.
+
+**Component Priority:**
+- `RetrievalAugmentor` takes precedence over `ContentRetriever`
+- `ToolProvider` is preferred over the `tools` array
+
+### Configuration-Based Plugin Creation
+
+Components can be created from configuration properties:
+
+```properties
+dev.langchain4j.plugin.<bean-name>.class=fully.qualified.ClassName
+dev.langchain4j.plugin.<bean-name>.scope=jakarta.enterprise.context.ApplicationScoped
+dev.langchain4j.plugin.<bean-name>.config.<property>=value
+```
+
+**Special lookup values:**
+- `lookup:@default` = select default CDI bean
+- `lookup:@all` = all beans of this type as a list
+- `lookup:<name>` = named bean
+
+The creator uses reflection to invoke the builder pattern (static `builder()` method + inner `*Builder` class).
+
+## Testing
+
+### Test Organization
+
+**langchain4j-cdi-integration-tests-common**: Shared test resources and utilities
+
+**langchain4j-cdi-integration-tests-quarkus**: Quarkus-specific integration tests
+- Fast feedback with Quarkus dev mode
+- Build-compatible extension validation
+
+**langchain4j-cdi-integration-tests-jakartaee**: Jakarta EE server tests
+- Tests for WildFly, GlassFish, Liberty, Payara
+- Portable extension validation
+- Uses Cargo Maven plugin for server management
+
+**langchain4j-cdi-integration-tests-helidon**: Helidon framework tests
+
+### Running Specific Test Modules
+
+Run Quarkus integration tests:
+```bash
+mvn test -pl langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus
+```
+
+Run Jakarta EE integration tests (note: longer execution time due to server startup):
+```bash
+mvn test -pl langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-jakartaee
+```
+
+## Examples
+
+All examples demonstrate a car booking application with chat, fraud detection, and function calling.
+
+**Recommended for Development:** `examples/quarkus-car-booking`
+- Fastest startup (~10 seconds)
+- Dev mode support with live reload
+- Best for rapid iteration
+
+**Other Examples:**
+- `examples/helidon-car-booking` and `examples/helidon-car-booking-portable-ext`
+- `examples/glassfish-car-booking`
+- `examples/liberty-car-booking`
+- `examples/payara-car-booking` (currently broken - always exclude)
+
+### Running Examples
+
+1. Install all core modules first:
+```bash
+mvn clean install -DskipTests -pl '!examples/payara-car-booking'
+```
+
+2. Navigate to example directory and run:
+```bash
+cd examples/quarkus-car-booking
+mvn quarkus:dev
+```
+
+3. Without Ollama, endpoints return connection errors (expected behavior)
+
+4. With Ollama, use the provided setup scripts in the examples directory
+
+## Code Quality
+
+**Formatter:** Palantir Java Format (via Spotless)
+- Style: PALANTIR
+- Includes Javadoc formatting
+- POM files are sorted with 4-space indentation
+
+**Pre-commit Checks:**
+```bash
+mvn spotless:check verify -pl '!examples/payara-car-booking'
+```
+
+**Auto-fix Formatting:**
+```bash
+mvn spotless:apply -pl '!examples/payara-car-booking'
+```
+
+## Contributing Workflow
+
+1. Build and test current state
+2. Make changes in the appropriate module
+3. Add unit tests in the same module
+4. Add integration tests if the change affects runtime behavior
+5. Format code: `mvn spotless:apply`
+6. Validate: `mvn spotless:check verify -pl '!examples/payara-car-booking'`
+7. Test with at least the Quarkus example application
+
+**Backward Compatibility:** Required - use `@Deprecated` instead of removing fields/methods
+
+**Avoid:**
+- Lombok in new code (remove from old code if possible)
+- New dependencies (check with `mvn dependency:analyze`)
+- Breaking changes
+
+## Common Patterns
+
+### AI Service Creation Flow
+
+1. `@RegisterAIService` annotated interface is detected by extension
+2. Extension processes annotation metadata at startup (portable) or build time (build-compatible)
+3. `CommonAIServiceCreator.create()` resolves CDI beans for each component
+4. LangChain4j `AiServices.builder()` is populated with resolved components
+5. Proxy implementation is created and registered as a CDI bean
+6. Service is injected into application beans
+
+### Configuration Loading
+
+1. `LLMConfigProvider` SPI implementations scan for configuration sources
+2. Properties matching `dev.langchain4j.plugin.*` or `langchain4j.*` are collected
+3. `CommonLLMPluginCreator` uses reflection to instantiate builders
+4. Builder methods are invoked with property values (type conversion handled)
+5. Special `lookup:*` values trigger CDI bean resolution
+6. Built instances are registered as CDI beans
+
+## Troubleshooting
+
+**Java Version Mismatch:** Ensure Java 21+ for builds, even though runtime target is Java 17
+
+**Spotless Failures:** Run `mvn spotless:apply` before committing
+
+**Payara Build Failures:** Always use `-pl '!examples/payara-car-booking'`
+
+**Integration Test Timeouts:** Jakarta EE tests take longer due to server startup (30+ seconds per server)
+
+**Missing Dependencies:** Run `mvn clean install` from repository root before working with examples

--- a/examples/car-booking-mcp/pom.xml
+++ b/examples/car-booking-mcp/pom.xml
@@ -66,7 +66,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${version.compiler.plugin}</version>
-                <configuration />
+                <configuration/>
             </plugin>
 
             <!--Build configuration for the WAR plugin: -->

--- a/examples/liberty-car-booking-mcp/pom.xml
+++ b/examples/liberty-car-booking-mcp/pom.xml
@@ -24,8 +24,8 @@
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <war-plugin.version>3.4.0</war-plugin.version>
         <!-- We need only javac to use the release parameter. OpenLiberty doesn't depend on maven-compiler-plugin.' -->
-        <maven.compiler.source combine.self="override" />
-        <maven.compiler.target combine.self="override" />
+        <maven.compiler.source combine.self="override"/>
+        <maven.compiler.target combine.self="override"/>
 
         <version.io.smallrye.fault-tolerance>6.7.3</version.io.smallrye.fault-tolerance>
         <!--Strictly for OpenLiberty-->

--- a/examples/liberty-car-booking/pom.xml
+++ b/examples/liberty-car-booking/pom.xml
@@ -24,8 +24,8 @@
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <war-plugin.version>3.4.0</war-plugin.version>
         <!-- We need only javac to use the release parameter. OpenLiberty doesn't depend on maven-compiler-plugin.' -->
-        <maven.compiler.source combine.self="override" />
-        <maven.compiler.target combine.self="override" />
+        <maven.compiler.source combine.self="override"/>
+        <maven.compiler.target combine.self="override"/>
 
         <version.io.smallrye.fault-tolerance>6.7.3</version.io.smallrye.fault-tolerance>
         <!--Strictly for OpenLiberty-->

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/aiservice/CdiLookupHelper.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/aiservice/CdiLookupHelper.java
@@ -1,0 +1,201 @@
+package dev.langchain4j.cdi.aiservice;
+
+import dev.langchain4j.cdi.spi.ExpressionResolver;
+import dev.langchain4j.guardrail.InputGuardrail;
+import dev.langchain4j.guardrail.OutputGuardrail;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.literal.NamedLiteral;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Shared CDI bean resolution utilities used by both {@link CommonAIServiceCreator} and
+ * {@link dev.langchain4j.cdi.agent.CommonAgentCreator}.
+ */
+public final class CdiLookupHelper {
+
+    private static final Logger LOGGER = Logger.getLogger(CdiLookupHelper.class.getName());
+    private static final String DEFAULT_BEAN_NAME = "#default";
+    private static final List<ExpressionResolver> EXPRESSION_RESOLVERS;
+
+    static {
+        List<ExpressionResolver> resolvers = new ArrayList<>();
+        ServiceLoader.load(ExpressionResolver.class).forEach(resolvers::add);
+        EXPRESSION_RESOLVERS = Collections.unmodifiableList(resolvers);
+    }
+
+    private CdiLookupHelper() {}
+
+    /** Returns {@code true} when {@code s} is non-null and contains at least one non-whitespace character. */
+    public static boolean hasText(String s) {
+        return s != null && !s.isBlank();
+    }
+
+    /**
+     * Resolves any expression embedded in {@code value} by applying all {@link ExpressionResolver} implementations
+     * discovered via {@link ServiceLoader}, in discovery order. Returns {@code value} unchanged when no resolvers are
+     * registered or the value is blank/null.
+     */
+    public static String resolveExpression(String value) {
+        if (!hasText(value)) {
+            return value;
+        }
+        String resolved = value;
+        for (ExpressionResolver resolver : EXPRESSION_RESOLVERS) {
+            resolved = resolver.resolve(resolved);
+        }
+        return resolved;
+    }
+
+    /**
+     * Resolve a CDI Instance for the given type and name. If name is {@code "#default"}, select the default bean of the
+     * given type. If name is blank or null, returns null (meaning: do not attempt to resolve). Expression patterns in
+     * {@code name} are expanded via {@link #resolveExpression(String)} before lookup.
+     */
+    public static <X> Instance<X> getInstance(Instance<Object> lookup, Class<X> type, String name) {
+        String resolved = resolveExpression(name);
+        if (hasText(resolved)) {
+            if (DEFAULT_BEAN_NAME.equals(resolved)) {
+                LOGGER.fine(() -> "Resolving default " + type.getSimpleName() + " bean");
+                return lookup.select(type);
+            }
+            LOGGER.fine(() -> "Resolving " + type.getSimpleName() + " bean named '" + resolved + "'");
+            return lookup.select(type, NamedLiteral.of(resolved));
+        }
+        return null;
+    }
+
+    /**
+     * Resolve a single bean instance by type and name, returning null if unresolvable. Convenience wrapper around
+     * {@link #getInstance} that extracts the bean.
+     */
+    public static <X> X resolveSingle(Instance<Object> lookup, Class<X> type, String name) {
+        Instance<X> instance = getInstance(lookup, type, name);
+        if (instance != null && instance.isResolvable()) {
+            return instance.get();
+        }
+        return null;
+    }
+
+    /**
+     * Resolve guardrail instances by class. For each class, first attempts CDI lookup; if the bean is not resolvable,
+     * falls back to instantiation via the no-arg constructor. Classes that fail both resolution paths are skipped with
+     * a WARNING log.
+     */
+    public static <G> List<G> resolveGuardrailsByClass(Instance<Object> lookup, Class<? extends G>[] guardrailClasses) {
+        List<G> guardrails = new ArrayList<>(guardrailClasses.length);
+        for (Class<? extends G> guardrailClass : guardrailClasses) {
+            try {
+                Instance<? extends G> guardrailInstance = lookup.select(guardrailClass);
+                if (guardrailInstance != null && guardrailInstance.isResolvable()) {
+                    guardrails.add(guardrailInstance.get());
+                } else {
+                    guardrails.add(
+                            guardrailClass.getConstructor((Class<?>[]) null).newInstance((Object[]) null));
+                }
+            } catch (ReflectiveOperationException | IllegalArgumentException ex) {
+                LOGGER.log(
+                        Level.WARNING,
+                        "Failed to create guardrail " + guardrailClass + ", skipping: " + ex.getMessage(),
+                        ex);
+            }
+        }
+        return guardrails;
+    }
+
+    /**
+     * Resolve guardrail instances by named CDI bean lookup. Names that cannot be resolved are skipped with a WARNING
+     * log.
+     */
+    public static <G> List<G> resolveGuardrailsByName(Instance<Object> lookup, Class<G> type, String[] names) {
+        List<G> guardrails = new ArrayList<>(names.length);
+        for (String name : names) {
+            try {
+                Instance<G> guardrailInstance = getInstance(lookup, type, name);
+                if (guardrailInstance != null && guardrailInstance.isResolvable()) {
+                    guardrails.add(guardrailInstance.get());
+                } else {
+                    LOGGER.log(Level.WARNING, "Named guardrail ''{0}'' is not resolvable, skipping", name);
+                }
+            } catch (IllegalArgumentException ex) {
+                LOGGER.log(
+                        Level.WARNING, "Failed to resolve guardrail '" + name + "', skipping: " + ex.getMessage(), ex);
+            }
+        }
+        return guardrails;
+    }
+
+    /**
+     * Resolve tool instances from an array of tool classes. For each class, first attempts CDI lookup; if the bean is
+     * not resolvable, falls back to instantiation via the no-arg constructor. Classes that fail both resolution paths
+     * are skipped with a SEVERE log.
+     */
+    public static List<Object> resolveToolInstances(Class<?>[] toolClasses, Instance<Object> lookup) {
+        List<Object> tools = new ArrayList<>(toolClasses.length);
+        for (Class<?> toolClass : toolClasses) {
+            try {
+                Instance<?> toolInstance = lookup.select(toolClass);
+                if (toolInstance != null && toolInstance.isResolvable()) {
+                    tools.add(toolInstance.get());
+                } else {
+                    tools.add(toolClass.getConstructor((Class<?>[]) null).newInstance((Object[]) null));
+                }
+            } catch (ReflectiveOperationException | IllegalArgumentException ex) {
+                LOGGER.log(Level.SEVERE, "Failed to create tool " + toolClass + ", skipping: " + ex.getMessage(), ex);
+            }
+        }
+        return tools;
+    }
+
+    /**
+     * Resolve input guardrails using class-vs-name precedence. When both {@code guardrailClasses} and
+     * {@code guardrailNames} are non-empty, classes take precedence and a WARNING is logged including
+     * {@code interfaceName} so operators can identify the offending service.
+     */
+    public static List<InputGuardrail> resolveInputGuardrails(
+            Instance<Object> lookup,
+            Class<? extends InputGuardrail>[] guardrailClasses,
+            String[] guardrailNames,
+            String interfaceName) {
+        if (guardrailClasses.length > 0 && guardrailNames.length > 0) {
+            LOGGER.log(
+                    Level.WARNING,
+                    "Both inputGuardrails and inputGuardrailNames specified for {0}. Using inputGuardrails classes and ignoring inputGuardrailNames.",
+                    interfaceName);
+        }
+        if (guardrailClasses.length > 0) {
+            return resolveGuardrailsByClass(lookup, guardrailClasses);
+        } else if (guardrailNames.length > 0) {
+            return resolveGuardrailsByName(lookup, InputGuardrail.class, guardrailNames);
+        }
+        return List.of();
+    }
+
+    /**
+     * Resolve output guardrails using class-vs-name precedence. When both {@code guardrailClasses} and
+     * {@code guardrailNames} are non-empty, classes take precedence and a WARNING is logged including
+     * {@code interfaceName} so operators can identify the offending service.
+     */
+    public static List<OutputGuardrail> resolveOutputGuardrails(
+            Instance<Object> lookup,
+            Class<? extends OutputGuardrail>[] guardrailClasses,
+            String[] guardrailNames,
+            String interfaceName) {
+        if (guardrailClasses.length > 0 && guardrailNames.length > 0) {
+            LOGGER.log(
+                    Level.WARNING,
+                    "Both outputGuardrails and outputGuardrailNames specified for {0}. Using outputGuardrails classes and ignoring outputGuardrailNames.",
+                    interfaceName);
+        }
+        if (guardrailClasses.length > 0) {
+            return resolveGuardrailsByClass(lookup, guardrailClasses);
+        } else if (guardrailNames.length > 0) {
+            return resolveGuardrailsByName(lookup, OutputGuardrail.class, guardrailNames);
+        }
+        return List.of();
+    }
+}

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/aiservice/CommonAIServiceCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/aiservice/CommonAIServiceCreator.java
@@ -13,10 +13,7 @@ import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.tool.ToolProvider;
 import jakarta.enterprise.inject.Instance;
-import jakarta.enterprise.inject.literal.NamedLiteral;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -33,7 +30,6 @@ import java.util.logging.Logger;
 public class CommonAIServiceCreator {
 
     private static final Logger LOGGER = Logger.getLogger(CommonAIServiceCreator.class.getName());
-    private static final String DEFAULT_BEAN_NAME = "#default";
 
     /**
      * Create a LangChain4j AI service proxy for the given annotated interface.
@@ -53,12 +49,13 @@ public class CommonAIServiceCreator {
         // Instances
         Instance<ChatModel> chatModelInstance = resolveChatModel(lookup, chatModelName, streamingChatModelName);
         Instance<StreamingChatModel> streamingChatModel =
-                getInstance(lookup, StreamingChatModel.class, streamingChatModelName);
+                CdiLookupHelper.getInstance(lookup, StreamingChatModel.class, streamingChatModelName);
         Instance<ContentRetriever> contentRetriever =
-                getInstance(lookup, ContentRetriever.class, annotation.contentRetrieverName());
+                CdiLookupHelper.getInstance(lookup, ContentRetriever.class, annotation.contentRetrieverName());
         Instance<RetrievalAugmentor> retrievalAugmentor =
-                getInstance(lookup, RetrievalAugmentor.class, annotation.retrievalAugmentorName());
-        Instance<ToolProvider> toolProvider = getInstance(lookup, ToolProvider.class, annotation.toolProviderName());
+                CdiLookupHelper.getInstance(lookup, RetrievalAugmentor.class, annotation.retrievalAugmentorName());
+        Instance<ToolProvider> toolProvider =
+                CdiLookupHelper.getInstance(lookup, ToolProvider.class, annotation.toolProviderName());
 
         AiServices<X> builder = AiServices.builder(interfaceClass);
         if (chatModelInstance != null && chatModelInstance.isResolvable()) {
@@ -82,27 +79,11 @@ public class CommonAIServiceCreator {
             LOGGER.fine("ToolProvider " + toolProvider.get());
             builder.toolProvider(toolProvider.get());
         } else if (annotation.tools().length > 0) {
-            List<Object> tools = new ArrayList<>(annotation.tools().length);
-            for (Class<?> toolClass : annotation.tools()) {
-                try {
-                    // First, check CDI.
-                    Instance<? extends Object> toolInstance = lookup.select(toolClass);
-                    if (toolInstance != null && toolInstance.isResolvable()) {
-                        tools.add(toolInstance.get());
-                    } else {
-                        tools.add(toolClass.getConstructor((Class<?>[]) null).newInstance((Object[]) null));
-                    }
-                } catch (ReflectiveOperationException | IllegalArgumentException ex) {
-                    LOGGER.log(
-                            Level.SEVERE,
-                            "Failed to create tool " + toolClass + " for " + interfaceClass + ", skipping: "
-                                    + ex.getMessage(),
-                            ex);
-                }
-            }
+            List<Object> tools = CdiLookupHelper.resolveToolInstances(annotation.tools(), lookup);
             builder.tools(tools);
         }
-        Instance<ChatMemory> chatMemory = getInstance(lookup, ChatMemory.class, annotation.chatMemoryName());
+        Instance<ChatMemory> chatMemory =
+                CdiLookupHelper.getInstance(lookup, ChatMemory.class, annotation.chatMemoryName());
         if (chatMemory != null && chatMemory.isResolvable()) {
             ChatMemory chatMemoryInstance = chatMemory.get();
             LOGGER.fine("ChatMemory " + chatMemoryInstance);
@@ -110,47 +91,29 @@ public class CommonAIServiceCreator {
         }
 
         Instance<ChatMemoryProvider> chatMemoryProvider =
-                getInstance(lookup, ChatMemoryProvider.class, annotation.chatMemoryProviderName());
+                CdiLookupHelper.getInstance(lookup, ChatMemoryProvider.class, annotation.chatMemoryProviderName());
         if (chatMemoryProvider != null && chatMemoryProvider.isResolvable()) {
             LOGGER.fine("ChatMemoryProvider " + chatMemoryProvider.get());
             builder.chatMemoryProvider(chatMemoryProvider.get());
         }
 
         Instance<ModerationModel> moderationModelInstance =
-                getInstance(lookup, ModerationModel.class, annotation.moderationModelName());
+                CdiLookupHelper.getInstance(lookup, ModerationModel.class, annotation.moderationModelName());
         if (moderationModelInstance != null && moderationModelInstance.isResolvable()) {
             LOGGER.fine("ModerationModel " + moderationModelInstance.get());
             builder.moderationModel(moderationModelInstance.get());
         }
-        List<InputGuardrail> inputGuardrails = new ArrayList<>();
-        if (annotation.inputGuardrails().length > 0 && annotation.inputGuardrailNames().length > 0) {
-            LOGGER.log(
-                    Level.WARNING,
-                    "Both inputGuardrails and inputGuardrailNames specified for {0}. Using inputGuardrails classes and ignoring inputGuardrailNames.",
-                    interfaceClass.getName());
-        }
-        if (annotation.inputGuardrails().length > 0) {
-            inputGuardrails.addAll(resolveGuardrails(lookup, annotation.inputGuardrails()));
-        } else if (annotation.inputGuardrailNames().length > 0) {
-            inputGuardrails.addAll(resolveGuardrails(lookup, InputGuardrail.class, annotation.inputGuardrailNames()));
-        }
+        List<InputGuardrail> inputGuardrails = CdiLookupHelper.resolveInputGuardrails(
+                lookup, annotation.inputGuardrails(), annotation.inputGuardrailNames(), interfaceClass.getSimpleName());
         if (!inputGuardrails.isEmpty()) {
             LOGGER.fine("InputGuardrails " + inputGuardrails);
             builder.inputGuardrails(inputGuardrails);
         }
-        List<OutputGuardrail> outputGuardrails = new ArrayList<>();
-        if (annotation.outputGuardrails().length > 0 && annotation.outputGuardrailNames().length > 0) {
-            LOGGER.log(
-                    Level.WARNING,
-                    "Both outputGuardrails and outputGuardrailNames specified for {0}. Using outputGuardrails classes and ignoring outputGuardrailNames.",
-                    interfaceClass.getName());
-        }
-        if (annotation.outputGuardrails().length > 0) {
-            outputGuardrails.addAll(resolveGuardrails(lookup, annotation.outputGuardrails()));
-        } else if (annotation.outputGuardrailNames().length > 0) {
-            outputGuardrails.addAll(
-                    resolveGuardrails(lookup, OutputGuardrail.class, annotation.outputGuardrailNames()));
-        }
+        List<OutputGuardrail> outputGuardrails = CdiLookupHelper.resolveOutputGuardrails(
+                lookup,
+                annotation.outputGuardrails(),
+                annotation.outputGuardrailNames(),
+                interfaceClass.getSimpleName());
         if (!outputGuardrails.isEmpty()) {
             LOGGER.fine("OutputGuardrails " + outputGuardrails);
             builder.outputGuardrails(outputGuardrails);
@@ -165,92 +128,14 @@ public class CommonAIServiceCreator {
      */
     private static Instance<ChatModel> resolveChatModel(
             Instance<Object> lookup, String chatModelName, String streamingChatModelName) {
-        Instance<ChatModel> chatModelInstance = getInstance(lookup, ChatModel.class, chatModelName);
+        Instance<ChatModel> chatModelInstance = CdiLookupHelper.getInstance(lookup, ChatModel.class, chatModelName);
 
         // If neither ChatModel nor StreamingChatModel is configured, try default ChatModel
         if ((chatModelInstance == null || !chatModelInstance.isResolvable())
-                && (streamingChatModelName == null || streamingChatModelName.isBlank())) {
+                && !CdiLookupHelper.hasText(streamingChatModelName)) {
             return lookup.select(ChatModel.class);
         }
 
         return chatModelInstance;
-    }
-
-    /**
-     * Resolve guardrail instances by class. For each class, first attempts CDI lookup; if the bean is not resolvable,
-     * falls back to instantiation via the no-arg constructor. Classes that fail both resolution paths are skipped with
-     * a WARNING log.
-     *
-     * @param lookup CDI Instance used for bean resolution.
-     * @param guardrailClasses the guardrail classes to resolve.
-     * @param <G> the guardrail type (InputGuardrail or OutputGuardrail).
-     * @return a list of resolved guardrail instances, in declaration order.
-     */
-    private static <G> List<G> resolveGuardrails(Instance<Object> lookup, Class<? extends G>[] guardrailClasses) {
-        List<G> guardrails = new ArrayList<>(guardrailClasses.length);
-        for (Class<? extends G> guardrailClass : guardrailClasses) {
-            try {
-                Instance<? extends G> guardrailInstance = lookup.select(guardrailClass);
-                if (guardrailInstance != null && guardrailInstance.isResolvable()) {
-                    guardrails.add(guardrailInstance.get());
-                } else {
-                    guardrails.add(
-                            guardrailClass.getConstructor((Class<?>[]) null).newInstance((Object[]) null));
-                }
-            } catch (ReflectiveOperationException | IllegalArgumentException ex) {
-                LOGGER.log(
-                        Level.WARNING,
-                        "Failed to create guardrail " + guardrailClass + ", skipping: " + ex.getMessage(),
-                        ex);
-            }
-        }
-        return guardrails;
-    }
-
-    /**
-     * Resolve guardrail instances by named CDI bean lookup. Each name is resolved via {@link #getInstance(Instance,
-     * Class, String)}. Names that cannot be resolved are skipped with a WARNING log.
-     *
-     * @param lookup CDI Instance used for bean resolution.
-     * @param type the guardrail interface class (e.g. InputGuardrail.class).
-     * @param guardrailNames the CDI bean names to resolve.
-     * @param <G> the guardrail type (InputGuardrail or OutputGuardrail).
-     * @return a list of resolved guardrail instances, in declaration order.
-     */
-    private static <G> List<G> resolveGuardrails(Instance<Object> lookup, Class<G> type, String[] guardrailNames) {
-        List<G> guardrails = new ArrayList<>(guardrailNames.length);
-        for (String guardrailName : guardrailNames) {
-            try {
-                Instance<? extends G> guardrailInstance = getInstance(lookup, type, guardrailName);
-                if (guardrailInstance != null && guardrailInstance.isResolvable()) {
-                    guardrails.add(guardrailInstance.get());
-                } else {
-                    LOGGER.log(Level.WARNING, "Named guardrail ''{0}'' is not resolvable, skipping", guardrailName);
-                }
-            } catch (IllegalArgumentException ex) {
-                LOGGER.log(
-                        Level.WARNING,
-                        "Failed to resolve guardrail '" + guardrailName + "', skipping: " + ex.getMessage(),
-                        ex);
-            }
-        }
-        return guardrails;
-    }
-
-    /**
-     * Resolve a CDI Instance for the given type and name. If name is "#default", select the default bean of the given
-     * type. If name is blank or null, returns null (meaning: do not attempt to resolve).
-     */
-    private static <X> Instance<X> getInstance(Instance<Object> lookup, Class<X> type, String name) {
-        LOGGER.fine("CDI get instance of type '" + type + "' with name '" + name + "'");
-        if (name != null && !name.isBlank()) {
-            if (DEFAULT_BEAN_NAME.equals(name)) {
-                return lookup.select(type);
-            }
-
-            return lookup.select(type, NamedLiteral.of(name));
-        }
-
-        return null;
     }
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/ExpressionResolver.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/ExpressionResolver.java
@@ -1,0 +1,23 @@
+package dev.langchain4j.cdi.spi;
+
+/**
+ * SPI for resolving expression strings embedded in {@link RegisterAgent} and {@link RegisterAIService} annotation
+ * attributes. Implementations are discovered via {@link java.util.ServiceLoader}.
+ *
+ * <p>Implementations should resolve expressions embedded in string values — for example, MicroProfile Config
+ * expressions like {@code ${my.property}} or system-property references. Strings that contain no expression must be
+ * returned unchanged.
+ *
+ * <p>If multiple implementations are registered, they are applied in discovery order: the output of each resolver is
+ * passed as the input to the next.
+ */
+public interface ExpressionResolver {
+
+    /**
+     * Resolves any expression embedded in {@code value}.
+     *
+     * @param value the raw annotation attribute value, never {@code null}
+     * @return the resolved value, never {@code null}
+     */
+    String resolve(String value);
+}

--- a/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/TestExpressionResolver.java
+++ b/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/TestExpressionResolver.java
@@ -1,0 +1,18 @@
+package dev.langchain4j.cdi.agent;
+
+import dev.langchain4j.cdi.spi.ExpressionResolver;
+
+/**
+ * Test-only ExpressionResolver that strips {@code ${...}} delimiters, so {@code ${#default}} resolves to
+ * {@code #default}, {@code ${mem1}} to {@code mem1}, etc. Plain strings are returned unchanged.
+ */
+public class TestExpressionResolver implements ExpressionResolver {
+
+    @Override
+    public String resolve(String value) {
+        if (value.startsWith("${") && value.endsWith("}")) {
+            return value.substring(2, value.length() - 1);
+        }
+        return value;
+    }
+}

--- a/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/aiservice/CommonAIServiceCreatorTest.java
+++ b/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/aiservice/CommonAIServiceCreatorTest.java
@@ -376,13 +376,9 @@ class CommonAIServiceCreatorTest {
     }
 
     @Test
-    void getInstance_returnsNullWhenNameBlank() throws Exception {
-        var m = CommonAIServiceCreator.class.getDeclaredMethod(
-                "getInstance", Instance.class, Class.class, String.class);
-        m.setAccessible(true);
+    void getInstance_returnsNullWhenNameBlank() {
         @SuppressWarnings("unchecked")
         Instance<Object> lookup = mock(Instance.class);
-        Object res = m.invoke(null, lookup, ChatModel.class, "");
-        assertNull(res);
+        assertNull(CdiLookupHelper.getInstance(lookup, ChatModel.class, ""));
     }
 }

--- a/langchain4j-cdi-core/src/test/resources/META-INF/services/dev.langchain4j.cdi.spi.ExpressionResolver
+++ b/langchain4j-cdi-core/src/test/resources/META-INF/services/dev.langchain4j.cdi.spi.ExpressionResolver
@@ -1,0 +1,1 @@
+dev.langchain4j.cdi.agent.TestExpressionResolver

--- a/langchain4j-cdi-el/pom.xml
+++ b/langchain4j-cdi-el/pom.xml
@@ -8,8 +8,8 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>langchain4j-cdi-portable-ext</artifactId>
-    <name>Langchain4J CDI: LangChain4j Portable Extension</name>
+    <artifactId>langchain4j-cdi-el</artifactId>
+    <name>Langchain4J CDI: Jakarta EL Expression Resolver</name>
 
     <dependencies>
         <dependency>
@@ -17,25 +17,12 @@
             <artifactId>langchain4j-cdi-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>dev.langchain4j</groupId>
-            <artifactId>langchain4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <!-- jakarta.el-api is a transitive dependency of cdi-api -->
             <scope>provided</scope>
         </dependency>
         <!-- TEST -->
-        <dependency>
-            <groupId>dev.langchain4j.cdi.mp</groupId>
-            <artifactId>langchain4j-cdi-config</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>dev.langchain4j.cdi</groupId>
-            <artifactId>langchain4j-cdi-el</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.glassfish.expressly</groupId>
             <artifactId>expressly</artifactId>
@@ -43,19 +30,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.smallrye.config</groupId>
-            <artifactId>smallrye-config</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.12.2</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-junit5</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-core-impl</artifactId>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/langchain4j-cdi-el/src/main/java/dev/langchain4j/cdi/el/JakartaELExpressionResolver.java
+++ b/langchain4j-cdi-el/src/main/java/dev/langchain4j/cdi/el/JakartaELExpressionResolver.java
@@ -1,0 +1,56 @@
+package dev.langchain4j.cdi.el;
+
+import dev.langchain4j.cdi.spi.ExpressionResolver;
+import jakarta.el.ELProcessor;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * ExpressionResolver that evaluates Jakarta EE Expression Language expressions enclosed in {@code #{...}} delimiters.
+ *
+ * <p>When a value matches the {@code #{...}} pattern, the enclosed string is evaluated as a Jakarta EL expression. CDI
+ * bean resolution is wired automatically when CDI is active at resolution time: the {@code BeanManager}'s ELResolver is
+ * added to the {@link ELProcessor} so that {@code @Named} beans can be referenced directly, for example
+ * {@code #{myService.modelName}}.
+ *
+ * <p>If CDI is not active (e.g. during unit tests), basic EL evaluation still works: arithmetic, string operations,
+ * system properties via {@code #{systemProperties['key']}}, etc.
+ *
+ * <p>If evaluation fails for any reason the original {@code #{...}} expression is returned unchanged and a WARNING is
+ * logged so the problem is visible rather than silently swallowed.
+ *
+ * <p>Registered automatically via {@link java.util.ServiceLoader} when this module is on the classpath.
+ */
+public class JakartaELExpressionResolver implements ExpressionResolver {
+
+    private static final Logger LOGGER = Logger.getLogger(JakartaELExpressionResolver.class.getName());
+
+    @Override
+    public String resolve(String value) {
+        if (!value.startsWith("#{") || !value.endsWith("}")) {
+            return value;
+        }
+        String expression = value.substring(2, value.length() - 1);
+        try {
+            Object result = newProcessor().eval(expression);
+            return result != null ? result.toString() : value;
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Failed to resolve Jakarta EL expression ''{0}'': {1}", new Object[] {
+                value, e.getMessage()
+            });
+            return value;
+        }
+    }
+
+    private static ELProcessor newProcessor() {
+        ELProcessor elp = new ELProcessor();
+        try {
+            jakarta.enterprise.inject.spi.BeanManager bm =
+                    jakarta.enterprise.inject.spi.CDI.current().getBeanManager();
+            elp.getELManager().addELResolver(bm.getELResolver());
+        } catch (IllegalStateException ignored) {
+            // CDI not active — basic EL evaluation proceeds without bean resolution
+        }
+        return elp;
+    }
+}

--- a/langchain4j-cdi-el/src/main/resources/META-INF/services/dev.langchain4j.cdi.spi.ExpressionResolver
+++ b/langchain4j-cdi-el/src/main/resources/META-INF/services/dev.langchain4j.cdi.spi.ExpressionResolver
@@ -1,0 +1,1 @@
+dev.langchain4j.cdi.el.JakartaELExpressionResolver

--- a/langchain4j-cdi-el/src/test/java/dev/langchain4j/cdi/el/JakartaELExpressionResolverTest.java
+++ b/langchain4j-cdi-el/src/test/java/dev/langchain4j/cdi/el/JakartaELExpressionResolverTest.java
@@ -1,0 +1,50 @@
+package dev.langchain4j.cdi.el;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class JakartaELExpressionResolverTest {
+
+    private final JakartaELExpressionResolver resolver = new JakartaELExpressionResolver();
+
+    @Test
+    void resolve_plainString_returnsUnchanged() {
+        assertEquals("plainValue", resolver.resolve("plainValue"));
+        assertEquals("#default", resolver.resolve("#default"));
+    }
+
+    @Test
+    void resolve_mpConfigPattern_returnsUnchanged() {
+        // ${...} is for MP Config, not EL — must pass through
+        assertEquals("${some.property}", resolver.resolve("${some.property}"));
+    }
+
+    @Test
+    void resolve_arithmeticExpression_returnsResult() {
+        assertEquals("3", resolver.resolve("#{1 + 2}"));
+    }
+
+    @Test
+    void resolve_stringLiteralExpression_returnsResult() {
+        assertEquals("hello", resolver.resolve("#{'hello'}"));
+    }
+
+    @Test
+    void resolve_conditionalExpression_returnsResult() {
+        assertEquals("yes", resolver.resolve("#{true ? 'yes' : 'no'}"));
+    }
+
+    @Test
+    void resolve_stringConcatenationExpression_returnsResult() {
+        // Standalone ELProcessor supports operators and string operations
+        assertEquals("foobar", resolver.resolve("#{'foo' += 'bar'}"));
+    }
+
+    @Test
+    void resolve_invalidExpression_returnsOriginal() {
+        // Unparseable expression → original is returned, no exception propagated
+        String bad = "#{[[[invalid}";
+        assertEquals(bad, resolver.resolve(bad));
+    }
+}

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/main/java/dev/langchain4j/cdi/core/integrationtests/ExpressionChatAiService.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/main/java/dev/langchain4j/cdi/core/integrationtests/ExpressionChatAiService.java
@@ -1,0 +1,13 @@
+package dev.langchain4j.cdi.core.integrationtests;
+
+import dev.langchain4j.cdi.spi.RegisterAIService;
+import dev.langchain4j.service.SystemMessage;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+@RegisterAIService(chatModelName = "${test.expression.model}", scope = ApplicationScoped.class)
+public interface ExpressionChatAiService {
+
+    @SystemMessage("my system message.")
+    String chat(String question);
+}

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/main/java/dev/langchain4j/cdi/core/integrationtests/ExpressionChatRestService.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/main/java/dev/langchain4j/cdi/core/integrationtests/ExpressionChatRestService.java
@@ -1,0 +1,22 @@
+package dev.langchain4j.cdi.core.integrationtests;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/expression-chat")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class ExpressionChatRestService {
+
+    @Inject
+    ExpressionChatAiService expressionChatAiService;
+
+    @POST
+    public String postChat(String chatRequest) {
+        return expressionChatAiService.chat(chatRequest);
+    }
+}

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/main/resources/application.properties
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 dev.langchain4j.cdi.plugin.chat-model.class=dev.langchain4j.cdi.core.integrationtests.ChatModelMock
+test.expression.model=chat-model
 
 quarkus.index-dependency.langchain4j-cdi.group-id=dev.langchain4j.cdi
 quarkus.index-dependency.langchain4j-cdi.artifact-id=langchain4j-cdi-integration-tests-common

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/test/java/dev/langchain4j/cdi/core/integrationtests/QuarkusExpressionResolverIntegrationTest.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/test/java/dev/langchain4j/cdi/core/integrationtests/QuarkusExpressionResolverIntegrationTest.java
@@ -1,0 +1,40 @@
+package dev.langchain4j.cdi.core.integrationtests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests verifying that the MP Config expression resolver resolves {@code ${test.expression.model}} to the
+ * {@code chat-model} bean name, which is then used to wire the AI service proxy in Quarkus.
+ */
+@QuarkusTest
+public class QuarkusExpressionResolverIntegrationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port")
+    int port;
+
+    @Test
+    public void testExpressionChatRestService() {
+        String chatEndpoint = "http://localhost:" + port + "/expression-chat";
+        try (Client client = ClientBuilder.newClient()) {
+            WebTarget target = client.target(chatEndpoint);
+
+            String question = "What is the meaning of life?";
+            Response response = target.request(MediaType.APPLICATION_JSON)
+                    .post(Entity.entity(question, MediaType.APPLICATION_JSON));
+
+            assertThat(response.getStatus()).isEqualTo(200);
+            String result = response.readEntity(String.class);
+            assertThat(result).isNotNull().isEqualTo("ok");
+        }
+    }
+}

--- a/langchain4j-cdi-mp/langchain4j-cdi-config/pom.xml
+++ b/langchain4j-cdi-mp/langchain4j-cdi-config/pom.xml
@@ -17,6 +17,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.12.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
             <artifactId>microprofile-config-api</artifactId>
             <scope>provided</scope>

--- a/langchain4j-cdi-mp/langchain4j-cdi-config/src/main/java/dev/langchain4j/cdi/core/mpconfig/MpConfigExpressionResolver.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-config/src/main/java/dev/langchain4j/cdi/core/mpconfig/MpConfigExpressionResolver.java
@@ -1,0 +1,44 @@
+package dev.langchain4j.cdi.core.mpconfig;
+
+import dev.langchain4j.cdi.spi.ExpressionResolver;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+/**
+ * ExpressionResolver that resolves {@code ${property.key}} expressions via MicroProfile Config.
+ *
+ * <p>When a value matches the {@code ${...}} pattern, the enclosed string is used as a MicroProfile Config property
+ * key. If the key is found, its value is returned; otherwise the original {@code ${...}} expression is returned
+ * unchanged so the problem is visible rather than silently swallowed.
+ *
+ * <p>Registered automatically via {@link java.util.ServiceLoader} when this module is on the classpath.
+ */
+public class MpConfigExpressionResolver implements ExpressionResolver {
+
+    private static final Logger LOGGER = Logger.getLogger(MpConfigExpressionResolver.class.getName());
+
+    @Override
+    public String resolve(String value) {
+        if (!value.startsWith("${") || !value.endsWith("}")) {
+            return value;
+        }
+        String key = value.substring(2, value.length() - 1);
+        try {
+            return ConfigProvider.getConfig()
+                    .getOptionalValue(key, String.class)
+                    .orElseGet(() -> {
+                        LOGGER.log(
+                                Level.FINE,
+                                "No MicroProfile Config value found for key ''{0}'', keeping original expression",
+                                key);
+                        return value;
+                    });
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Failed to resolve MicroProfile Config property ''{0}'': {1}", new Object[] {
+                key, e.getMessage()
+            });
+            return value;
+        }
+    }
+}

--- a/langchain4j-cdi-mp/langchain4j-cdi-config/src/main/resources/META-INF/services/dev.langchain4j.cdi.spi.ExpressionResolver
+++ b/langchain4j-cdi-mp/langchain4j-cdi-config/src/main/resources/META-INF/services/dev.langchain4j.cdi.spi.ExpressionResolver
@@ -1,0 +1,1 @@
+dev.langchain4j.cdi.core.mpconfig.MpConfigExpressionResolver

--- a/langchain4j-cdi-mp/langchain4j-cdi-config/src/test/java/dev/langchain4j/cdi/core/mpconfig/MpConfigExpressionResolverTest.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-config/src/test/java/dev/langchain4j/cdi/core/mpconfig/MpConfigExpressionResolverTest.java
@@ -1,0 +1,39 @@
+package dev.langchain4j.cdi.core.mpconfig;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class MpConfigExpressionResolverTest {
+
+    private final MpConfigExpressionResolver resolver = new MpConfigExpressionResolver();
+
+    @Test
+    void resolve_plainString_returnsUnchanged() {
+        assertEquals("plainValue", resolver.resolve("plainValue"));
+        assertEquals("#default", resolver.resolve("#default"));
+    }
+
+    @Test
+    void resolve_eelPattern_returnsUnchanged() {
+        // #{...} is for EL, not MP Config — must pass through
+        assertEquals("#{someBean.prop}", resolver.resolve("#{someBean.prop}"));
+    }
+
+    @Test
+    void resolve_knownProperty_returnsConfigValue() {
+        // "test.agent.model" = "my-model" is defined in src/test/resources/META-INF/microprofile-config.properties
+        assertEquals("my-model", resolver.resolve("${test.agent.model}"));
+    }
+
+    @Test
+    void resolve_knownPropertyForName_returnsConfigValue() {
+        assertEquals("reviewAgent", resolver.resolve("${test.agent.name}"));
+    }
+
+    @Test
+    void resolve_unknownProperty_returnsOriginalExpression() {
+        // Unknown key → original expression returned so it is visible
+        assertEquals("${nonexistent.key}", resolver.resolve("${nonexistent.key}"));
+    }
+}

--- a/langchain4j-cdi-mp/langchain4j-cdi-config/src/test/resources/META-INF/microprofile-config.properties
+++ b/langchain4j-cdi-mp/langchain4j-cdi-config/src/test/resources/META-INF/microprofile-config.properties
@@ -1,0 +1,2 @@
+test.agent.model=my-model
+test.agent.name=reviewAgent

--- a/langchain4j-cdi-portable-ext/src/test/java/dev/langchain4j/cdi/core/ELExpressionAIService.java
+++ b/langchain4j-cdi-portable-ext/src/test/java/dev/langchain4j/cdi/core/ELExpressionAIService.java
@@ -1,0 +1,10 @@
+package dev.langchain4j.cdi.core;
+
+import dev.langchain4j.cdi.spi.RegisterAIService;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+@RegisterAIService(chatModelName = "#{true ? 'chat-model-dummy' : 'other'}", scope = ApplicationScoped.class)
+public interface ELExpressionAIService {
+    String chat(String question);
+}

--- a/langchain4j-cdi-portable-ext/src/test/java/dev/langchain4j/cdi/core/ExpressionResolverWeldIntegrationTest.java
+++ b/langchain4j-cdi-portable-ext/src/test/java/dev/langchain4j/cdi/core/ExpressionResolverWeldIntegrationTest.java
@@ -1,0 +1,52 @@
+package dev.langchain4j.cdi.core;
+
+import dev.langchain4j.cdi.core.portableextension.LangChain4JAIServicePortableExtension;
+import dev.langchain4j.cdi.core.portableextension.LangChain4JPluginsPortableExtension;
+import io.smallrye.config.inject.ConfigExtension;
+import jakarta.inject.Inject;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Integration tests verifying that expression resolvers (MP Config and Jakarta EL) are applied when creating AI service
+ * proxies via the CDI portable extension in a Weld container.
+ */
+@ExtendWith(WeldJunit5Extension.class)
+public class ExpressionResolverWeldIntegrationTest {
+
+    @Inject
+    MpConfigExpressionAIService mpConfigAIService;
+
+    @Inject
+    ELExpressionAIService elAIService;
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.from(
+                    LangChain4JAIServicePortableExtension.class,
+                    LangChain4JPluginsPortableExtension.class,
+                    MpConfigExpressionAIService.class,
+                    ELExpressionAIService.class,
+                    DummyChatModel.class,
+                    DummyEmbeddingStore.class,
+                    DummyEmbeddingModel.class,
+                    ConfigExtension.class)
+            .build();
+
+    @Test
+    void mpConfigExpression_resolvesModelName() {
+        // ${test.expression.model.name} is resolved to "chat-model-dummy" via MP Config
+        Assertions.assertNotNull(mpConfigAIService);
+        Assertions.assertNotNull(mpConfigAIService.toString());
+    }
+
+    @Test
+    void elExpression_resolvesModelName() {
+        // #{true ? 'chat-model-dummy' : 'other'} is evaluated to "chat-model-dummy" via Jakarta EL
+        Assertions.assertNotNull(elAIService);
+        Assertions.assertNotNull(elAIService.toString());
+    }
+}

--- a/langchain4j-cdi-portable-ext/src/test/java/dev/langchain4j/cdi/core/MpConfigExpressionAIService.java
+++ b/langchain4j-cdi-portable-ext/src/test/java/dev/langchain4j/cdi/core/MpConfigExpressionAIService.java
@@ -1,0 +1,10 @@
+package dev.langchain4j.cdi.core;
+
+import dev.langchain4j.cdi.spi.RegisterAIService;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+@RegisterAIService(chatModelName = "${test.expression.model.name}", scope = ApplicationScoped.class)
+public interface MpConfigExpressionAIService {
+    String chat(String question);
+}

--- a/langchain4j-cdi-portable-ext/src/test/resources/META-INF/microprofile-config.properties
+++ b/langchain4j-cdi-portable-ext/src/test/resources/META-INF/microprofile-config.properties
@@ -2,6 +2,7 @@ dev.langchain4j.cdi.plugin.chat-model-dummy.class=dev.langchain4j.cdi.core.Dummy
 dev.langchain4j.cdi.plugin.chat-model-dummy.config.api-key=apikey
 dev.langchain4j.cdi.plugin.chat-model-dummy.config.embedding-model=lookup:myModel
 dev.langchain4j.cdi.plugin.chat-model-dummy.config.embedding-model2=lookup:@default
+test.expression.model.name=chat-model-dummy
 
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <module>langchain4j-cdi-portable-ext</module>
         <module>langchain4j-cdi-build-compatible-ext</module>
         <module>langchain4j-cdi-core</module>
+        <module>langchain4j-cdi-el</module>
         <module>langchain4j-cdi-mp</module>
         <module>langchain4j-cdi-mcp</module>
     </modules>
@@ -66,8 +67,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>2026-03-31T09:54:21Z</project.build.outputTimestamp>
 
-        <dev.langchain4j.version>1.12.2</dev.langchain4j.version>
-        <dev.langchain4j.community.version>1.12.2-beta22</dev.langchain4j.community.version>
+        <dev.langchain4j.version>1.14.0</dev.langchain4j.version>
+        <dev.langchain4j.community.version>1.14.0-beta24</dev.langchain4j.community.version>
         <jakartaee-api.version>10.0.0</jakartaee-api.version>
         <jakarta.enterprise.cdi-api.version>4.0.1</jakarta.enterprise.cdi-api.version>
         <org.mcp-java.version>1.0.0-Beta1</org.mcp-java.version>
@@ -140,6 +141,11 @@
             <dependency>
                 <groupId>dev.langchain4j.cdi</groupId>
                 <artifactId>langchain4j-cdi-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j.cdi</groupId>
+                <artifactId>langchain4j-cdi-el</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
Introduces a ServiceLoader-discovered ExpressionResolver pipeline so that annotation attributes can embed ${...} (MicroProfile Config) and #{...} (Jakarta EL) expressions. 
Extracts shared CDI-lookup helpers from CommonAIServiceCreator into CdiLookupHelper, which also owns expression resolution and the hasText() null/blank utility.