### PR TITLE
Preparing the 1.3.1 release

### DIFF
--- a/examples/car-booking-mcp/pom.xml
+++ b/examples/car-booking-mcp/pom.xml
@@ -66,7 +66,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${version.compiler.plugin}</version>
-                <configuration />
+                <configuration/>
             </plugin>
 
             <!--Build configuration for the WAR plugin: -->

--- a/examples/liberty-car-booking-mcp/pom.xml
+++ b/examples/liberty-car-booking-mcp/pom.xml
@@ -24,8 +24,8 @@
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <war-plugin.version>3.4.0</war-plugin.version>
         <!-- We need only javac to use the release parameter. OpenLiberty doesn't depend on maven-compiler-plugin.' -->
-        <maven.compiler.source combine.self="override" />
-        <maven.compiler.target combine.self="override" />
+        <maven.compiler.source combine.self="override"/>
+        <maven.compiler.target combine.self="override"/>
 
         <version.io.smallrye.fault-tolerance>6.7.3</version.io.smallrye.fault-tolerance>
         <!--Strictly for OpenLiberty-->

--- a/examples/liberty-car-booking/pom.xml
+++ b/examples/liberty-car-booking/pom.xml
@@ -24,8 +24,8 @@
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <war-plugin.version>3.4.0</war-plugin.version>
         <!-- We need only javac to use the release parameter. OpenLiberty doesn't depend on maven-compiler-plugin.' -->
-        <maven.compiler.source combine.self="override" />
-        <maven.compiler.target combine.self="override" />
+        <maven.compiler.source combine.self="override"/>
+        <maven.compiler.target combine.self="override"/>
 
         <version.io.smallrye.fault-tolerance>6.7.3</version.io.smallrye.fault-tolerance>
         <!--Strictly for OpenLiberty-->

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
@@ -138,15 +138,23 @@ public class CommonAgentCreator {
 
         Method entryMethod = findEntryMethod(interfaceClass);
         if (entryMethod != null && entryMethod.isAnnotationPresent(Agent.class)) {
-            return AgenticServices.createAgenticSystem(interfaceClass, chatModel, ctx -> {
-                var builder = ctx.agentBuilder();
-                if (streamingChatModel != null) {
-                    builder.streamingChatModel(streamingChatModel);
-                }
-                AgentComponents.resolve(ann, lookup, interfaceClass.getSimpleName())
-                        .applyTo(builder);
-                applyListener(builder::listener, ann.agentListenerName(), lookup);
-            });
+            return AgenticServices.createAgenticSystem(
+                    interfaceClass,
+                    chatModel,
+                    new AgenticServices.AgentConfigurator(
+                            ctx -> {
+                                var builder = ctx.agentBuilder();
+                                if (streamingChatModel != null) {
+                                    builder.streamingChatModel(streamingChatModel);
+                                }
+                                AgentComponents.resolve(ann, lookup, interfaceClass.getSimpleName())
+                                        .applyTo(builder);
+                                applyListener(builder::listener, ann.agentListenerName(), lookup);
+                            },
+                            agentClass -> {
+                                Instance<?> instance = lookup.select(agentClass);
+                                return instance.isResolvable() ? instance.get() : null;
+                            }));
         }
 
         X aiService = buildAiServiceForSimple(interfaceClass, ann, chatModel, streamingChatModel, lookup);

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
@@ -52,6 +52,7 @@ import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.CDI;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -963,7 +964,7 @@ public class CommonAgentCreator {
     private static Method findEntryMethod(Class<?> agentInterface) {
         // Check methods declared directly on the interface first.
         List<Method> declared = Arrays.stream(agentInterface.getDeclaredMethods())
-                .filter(m -> !m.isDefault())
+                .filter(m -> !m.isDefault() && !Modifier.isStatic(m.getModifiers()))
                 .toList();
         if (declared.size() > 1) {
             throw new IllegalArgumentException("Agent interface "
@@ -978,7 +979,7 @@ public class CommonAgentCreator {
         // interfaces. This handles the pattern where the entry method is declared in a shared base
         // interface extended by the agent interface.
         List<Method> inherited = Arrays.stream(agentInterface.getMethods())
-                .filter(m -> !m.isDefault() && !m.isSynthetic())
+                .filter(m -> !m.isDefault() && !m.isSynthetic() && !Modifier.isStatic(m.getModifiers()))
                 .distinct()
                 .toList();
         if (inherited.size() > 1) {

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
@@ -547,11 +547,15 @@ public class CommonAgentCreator {
         static AgentComponents resolve(RegisterSimpleAgent ann, Instance<Object> lookup, String interfaceName) {
             ToolProvider toolProvider =
                     CdiLookupHelper.resolveSingle(lookup, ToolProvider.class, ann.toolProviderName());
-            List<Object> tools = ann.toolNames().length > 0
-                    ? CdiLookupHelper.resolveToolsByName(ann.toolNames(), lookup)
-                    : List.of();
+            List<Object> tools = new java.util.ArrayList<>();
+            if (ann.tools().length > 0) {
+                tools.addAll(CdiLookupHelper.resolveToolInstances(ann.tools(), lookup));
+            }
+            if (ann.toolNames().length > 0) {
+                tools.addAll(CdiLookupHelper.resolveToolsByName(ann.toolNames(), lookup));
+            }
             if (toolProvider != null && !tools.isEmpty()) {
-                LOGGER.warning("Both toolProviderName and toolNames[] are configured on "
+                LOGGER.warning("Both toolProviderName and tools/toolNames[] are configured on "
                         + interfaceName
                         + "; overlapping tool names will cause IllegalConfigurationException at runtime.");
             }
@@ -563,10 +567,10 @@ public class CommonAgentCreator {
             ContentRetriever contentRetriever = retrievalAugmentor == null
                     ? CdiLookupHelper.resolveSingle(lookup, ContentRetriever.class, ann.contentRetrieverName())
                     : null;
-            List<InputGuardrail> inputGuardrails =
-                    CdiLookupHelper.resolveGuardrailsByName(lookup, InputGuardrail.class, ann.inputGuardrailNames());
-            List<OutputGuardrail> outputGuardrails =
-                    CdiLookupHelper.resolveGuardrailsByName(lookup, OutputGuardrail.class, ann.outputGuardrailNames());
+            List<InputGuardrail> inputGuardrails = CdiLookupHelper.resolveInputGuardrails(
+                    lookup, ann.inputGuardrails(), ann.inputGuardrailNames(), interfaceName);
+            List<OutputGuardrail> outputGuardrails = CdiLookupHelper.resolveOutputGuardrails(
+                    lookup, ann.outputGuardrails(), ann.outputGuardrailNames(), interfaceName);
             return new AgentComponents(
                     toolProvider,
                     tools,

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSimpleAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSimpleAgent.java
@@ -2,6 +2,8 @@ package dev.langchain4j.cdi.spi;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import dev.langchain4j.guardrail.InputGuardrail;
+import dev.langchain4j.guardrail.OutputGuardrail;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Stereotype;
 import java.lang.annotation.Annotation;
@@ -38,8 +40,16 @@ public @interface RegisterSimpleAgent {
     String streamingChatModelName() default "";
 
     /**
-     * CDI bean names of tool objects to register. Each name must resolve to a {@code @Named} CDI bean. Ignored when
-     * {@link #toolProviderName()} is set.
+     * Tool classes to wire into the agent. Each class is resolved as a CDI bean when possible, or instantiated via its
+     * no-arg constructor otherwise. Can be used together with {@link #toolNames()} and {@link #toolProviderName()}: all
+     * present sources are applied. Avoid overlapping tool names across sources — LangChain4j will throw
+     * {@code IllegalConfigurationException} at runtime if the same tool name appears more than once.
+     */
+    Class<?>[] tools() default {};
+
+    /**
+     * CDI bean names of tool objects to register. Each name must resolve to a {@code @Named} CDI bean. Can be used
+     * together with {@link #tools()} and {@link #toolProviderName()}.
      */
     String[] toolNames() default {};
 
@@ -53,7 +63,31 @@ public @interface RegisterSimpleAgent {
 
     String retrievalAugmentorName() default "";
 
+    /**
+     * Input guardrail classes to validate messages before sending to the LLM. If a class is a CDI managed bean, the
+     * bean instance is used; otherwise it is instantiated via its no-arg constructor. Mutually exclusive with
+     * {@link #inputGuardrailNames()}: if both are specified, only the classes are used and the names are ignored.
+     */
+    Class<? extends InputGuardrail>[] inputGuardrails() default {};
+
+    /**
+     * Output guardrail classes to validate LLM responses before returning them. If a class is a CDI managed bean, the
+     * bean instance is used; otherwise it is instantiated via its no-arg constructor. Mutually exclusive with
+     * {@link #outputGuardrailNames()}: if both are specified, only the classes are used and the names are ignored.
+     */
+    Class<? extends OutputGuardrail>[] outputGuardrails() default {};
+
+    /**
+     * Named CDI beans implementing {@link InputGuardrail} to validate messages before sending to the LLM. Unresolvable
+     * names are skipped with a WARNING log. Mutually exclusive with {@link #inputGuardrails()}: if both are specified,
+     * only the classes are used and the names are ignored.
+     */
     String[] inputGuardrailNames() default {};
 
+    /**
+     * Named CDI beans implementing {@link OutputGuardrail} to validate LLM responses before returning them.
+     * Unresolvable names are skipped with a WARNING log. Mutually exclusive with {@link #outputGuardrails()}: if both
+     * are specified, only the classes are used and the names are ignored.
+     */
     String[] outputGuardrailNames() default {};
 }

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>2026-05-19T12:22:35Z</project.build.outputTimestamp>
 
-        <dev.langchain4j.version>1.15.0</dev.langchain4j.version>
-        <dev.langchain4j.agentic.version>1.15.0-beta25</dev.langchain4j.agentic.version>
-        <dev.langchain4j.community.version>1.15.0-beta25</dev.langchain4j.community.version>
+        <dev.langchain4j.version>1.15.1</dev.langchain4j.version>
+        <dev.langchain4j.agentic.version>1.15.1-beta25</dev.langchain4j.agentic.version>
+        <dev.langchain4j.community.version>1.15.1-beta25</dev.langchain4j.community.version>
         <jakartaee-api.version>10.0.0</jakartaee-api.version>
         <jakarta.enterprise.cdi-api.version>4.0.1</jakarta.enterprise.cdi-api.version>
         <org.mcp-java.version>1.0.0-Beta1</org.mcp-java.version>


### PR DESCRIPTION
- Updating LC4J to 1.15.1
- Align the implementation of the @RegisterSimpleAgent and @RegisterAIService annotations
- Exclude static methods when detecting agent entry point

