### PR TITLE
fix: forward name/description/outputKey/async to AgentBuilder in @RegisterSimpleAgent @agent path

### DIFF
--- a/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/aiservice/Langchain4JAIServiceBuildCompatibleExtension.java
+++ b/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/aiservice/Langchain4JAIServiceBuildCompatibleExtension.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.cdi.aiservice;
 
+import dev.langchain4j.agentic.internal.AgenticScopeOwner;
 import dev.langchain4j.agentic.internal.InternalAgent;
 import dev.langchain4j.cdi.agent.AgentAnnotationMeta;
 import dev.langchain4j.cdi.agent.CommonAgentCreator;
@@ -205,6 +206,7 @@ public class Langchain4JAIServiceBuildCompatibleExtension implements BuildCompat
             builder.createWith(AIAgentCreator.class)
                     .type(interfaceClass)
                     .type(InternalAgent.class)
+                    .type(AgenticScopeOwner.class)
                     .type(Object.class)
                     .scope(scope)
                     .name(beanName)

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
@@ -10,6 +10,7 @@ import dev.langchain4j.agentic.internal.AgentExecutor;
 import dev.langchain4j.agentic.internal.AgentInvoker;
 import dev.langchain4j.agentic.internal.AgentSpecsProvider;
 import dev.langchain4j.agentic.internal.AgentUtil;
+import dev.langchain4j.agentic.internal.AgenticScopeOwner;
 import dev.langchain4j.agentic.internal.InternalAgent;
 import dev.langchain4j.agentic.internal.McpService;
 import dev.langchain4j.agentic.internal.NonAiAgentInstance;
@@ -195,6 +196,12 @@ public class CommonAgentCreator {
             // InternalAgent and its supertypes, routing the full internal-method hierarchy here.
             if (declaringClass.isAssignableFrom(InternalAgent.class)) {
                 return method.invoke(agentInstance, args);
+            }
+            // Simple AI-service agents have no planner scope. When AgentExecutor calls
+            // withAgenticScope() via the Weld scope proxy (which now exposes AgenticScopeOwner),
+            // return this proxy unchanged so execution continues without binding a child scope.
+            if (declaringClass.isAssignableFrom(AgenticScopeOwner.class)) {
+                return method.getName().equals("withAgenticScope") ? proxy : null;
             }
             return method.invoke(aiService, args);
         };

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
@@ -150,6 +150,19 @@ public class CommonAgentCreator {
                                 }
                                 AgentComponents.resolve(ann, lookup, interfaceClass.getSimpleName())
                                         .applyTo(builder);
+                                String resolvedName = CdiLookupHelper.resolveExpression(ann.name());
+                                if (hasText(resolvedName)) {
+                                    builder.name(resolvedName);
+                                }
+                                String resolvedDescription = CdiLookupHelper.resolveExpression(ann.description());
+                                if (hasText(resolvedDescription)) {
+                                    builder.description(resolvedDescription);
+                                }
+                                String resolvedOutputKey = CdiLookupHelper.resolveExpression(ann.outputKey());
+                                if (hasText(resolvedOutputKey)) {
+                                    builder.outputKey(resolvedOutputKey);
+                                }
+                                builder.async(ann.async());
                                 applyListener(builder::listener, ann.agentListenerName(), lookup);
                             },
                             agentClass -> {
@@ -176,7 +189,11 @@ public class CommonAgentCreator {
                     default -> method.invoke(aiService, args);
                 };
             }
-            if (InternalAgent.class.isAssignableFrom(declaringClass)) {
+            // InternalAgent extends AgentInstance, so methods declared on AgentInstance (name,
+            // outputKey, etc.) have declaringClass == AgentInstance. The reversed direction
+            // "declaringClass.isAssignableFrom(InternalAgent.class)" returns true for both
+            // InternalAgent and its supertypes, routing the full internal-method hierarchy here.
+            if (declaringClass.isAssignableFrom(InternalAgent.class)) {
                 return method.invoke(agentInstance, args);
             }
             return method.invoke(aiService, args);
@@ -425,7 +442,7 @@ public class CommonAgentCreator {
             if (HumanInTheLoopHolder.class.isAssignableFrom(declaringClass)) {
                 return spec;
             }
-            if (InternalAgent.class.isAssignableFrom(declaringClass)) {
+            if (declaringClass.isAssignableFrom(InternalAgent.class)) {
                 return method.invoke(agentInstance, args);
             }
             throw new UnsupportedOperationException(

--- a/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/CommonAgentCreatorTest.java
+++ b/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/CommonAgentCreatorTest.java
@@ -113,10 +113,38 @@ class CommonAgentCreatorTest {
         String chat(@V("question") String question);
     }
 
+    @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+    @RegisterSimpleAgent(chatModelName = "#default", outputKey = "myKey")
+    interface AgentWithOutputKey {
+
+        String chat(@V("question") String question);
+    }
+
     // --- Test interface for SIMPLE topology (@Agent path) ---
     @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
     @RegisterSimpleAgent(chatModelName = "#default")
     interface AgenticAgent {
+
+        @Agent(description = "test agent")
+        String process(@V("input") String input);
+    }
+
+    @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+    @RegisterSimpleAgent(chatModelName = "#default", outputKey = "agentOutput")
+    interface AgenticAgentWithOutputKey {
+
+        @Agent(description = "test agent")
+        String process(@V("input") String input);
+    }
+
+    @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+    @RegisterSimpleAgent(
+            chatModelName = "#default",
+            name = "myAgenticAgent",
+            description = "an agentic agent",
+            outputKey = "myOutput",
+            async = true)
+    interface AgenticAgentWithMetadata {
 
         @Agent(description = "test agent")
         String process(@V("input") String input);
@@ -530,6 +558,16 @@ class CommonAgentCreatorTest {
         assertInstanceOf(InternalAgent.class, agent);
     }
 
+    @Test
+    void create_simpleTopology_noAgentAnnotation_propagatesOutputKey() {
+        Instance<Object> lookup = prepareLookups();
+        AgentWithOutputKey agent = CommonAgentCreator.create(lookup, AgentWithOutputKey.class);
+
+        assertNotNull(agent);
+        assertInstanceOf(InternalAgent.class, agent);
+        assertEquals("myKey", ((InternalAgent) agent).outputKey());
+    }
+
     // =========================================================================
     // SIMPLE topology -- @Agent path
     // =========================================================================
@@ -540,6 +578,30 @@ class CommonAgentCreatorTest {
 
         assertNotNull(agent);
         assertInstanceOf(InternalAgent.class, agent);
+    }
+
+    @Test
+    void create_simpleTopology_withAgentAnnotation_propagatesOutputKey() {
+        Instance<Object> lookup = prepareLookups();
+        AgenticAgentWithOutputKey agent = CommonAgentCreator.create(lookup, AgenticAgentWithOutputKey.class);
+
+        assertNotNull(agent);
+        assertInstanceOf(InternalAgent.class, agent);
+        assertEquals("agentOutput", ((InternalAgent) agent).outputKey());
+    }
+
+    @Test
+    void create_simpleTopology_withAgentAnnotation_honorsOutputKeyNameDescriptionAsync() {
+        Instance<Object> lookup = prepareLookups();
+        AgenticAgentWithMetadata agent = CommonAgentCreator.create(lookup, AgenticAgentWithMetadata.class);
+
+        assertNotNull(agent);
+        assertInstanceOf(InternalAgent.class, agent);
+        InternalAgent ia = (InternalAgent) agent;
+        assertEquals("myAgenticAgent", ia.name());
+        assertEquals("an agentic agent", ia.description());
+        assertEquals("myOutput", ia.outputKey());
+        assertTrue(ia.async());
     }
 
     // =========================================================================

--- a/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/LangChain4JAIAgentBean.java
+++ b/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/LangChain4JAIAgentBean.java
@@ -80,9 +80,7 @@ public class LangChain4JAIAgentBean<T> implements Bean<T>, PassivationCapable {
         Set<Annotation> annotations = new HashSet<>();
         annotations.add(new AnnotationLiteral<Default>() {});
         annotations.add(new AnnotationLiteral<Any>() {});
-        if (agentName != null) {
-            annotations.add(NamedLiteral.of(agentName));
-        }
+        annotations.add(NamedLiteral.of(getName()));
         return Collections.unmodifiableSet(annotations);
     }
 

--- a/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/LangChain4JAIAgentBean.java
+++ b/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/LangChain4JAIAgentBean.java
@@ -1,5 +1,6 @@
 package dev.langchain4j.cdi.core.portableextension;
 
+import dev.langchain4j.agentic.internal.AgenticScopeOwner;
 import dev.langchain4j.agentic.internal.InternalAgent;
 import dev.langchain4j.cdi.agent.AgentAnnotationMeta;
 import dev.langchain4j.cdi.agent.CommonAgentCreator;
@@ -71,6 +72,7 @@ public class LangChain4JAIAgentBean<T> implements Bean<T>, PassivationCapable {
         Set<Type> types = new HashSet<>();
         types.add(agentInterfaceClass);
         types.add(InternalAgent.class);
+        types.add(AgenticScopeOwner.class);
         types.add(Object.class);
         return Collections.unmodifiableSet(types);
     }

--- a/langchain4j-cdi-portable-ext/src/test/java/dev/langchain4j/cdi/core/AgentPortableExtensionTest.java
+++ b/langchain4j-cdi-portable-ext/src/test/java/dev/langchain4j/cdi/core/AgentPortableExtensionTest.java
@@ -100,6 +100,35 @@ public class AgentPortableExtensionTest {
         Assertions.assertEquals("namedAgent", namedBean.getName());
     }
 
+    @Test
+    void namedAgentBeanAlwaysHasNamedQualifier() {
+        // Same Liberty-container concern applies to named agents: @Named must be in getQualifiers(),
+        // not just returned by getName().
+        Set<Bean<?>> byName = beanManager.getBeans("namedAgent");
+        Assertions.assertFalse(byName.isEmpty(), "BeanManager.getBeans(name) must find named agent bean");
+
+        Bean<?> bean = byName.iterator().next();
+        boolean hasNamedQualifier = bean.getQualifiers().stream()
+                .anyMatch(q -> q instanceof Named named && named.value().equals("namedAgent"));
+        Assertions.assertTrue(hasNamedQualifier, "Named agent bean must have @Named(\"namedAgent\") qualifier");
+    }
+
+    @Test
+    void unnamedAgentBeanAlwaysHasNamedQualifier() {
+        // BeanManager.getBeans(String) on some CDI containers (e.g. Liberty) only indexes beans
+        // that carry an actual @Named qualifier — not beans that merely override getName(). Ensure
+        // LangChain4JAIAgentBean always adds @Named(getName()) so the BeanManager fallback in
+        // toAgentExecutor works on all containers.
+        String expectedName = CommonAgentCreator.AGENT_BEAN_NAME_PREFIX + MyDummyAgent.class.getName();
+        Set<Bean<?>> byName = beanManager.getBeans(expectedName);
+        Assertions.assertFalse(byName.isEmpty(), "BeanManager.getBeans(name) must find unnamed agent bean");
+
+        Bean<?> bean = byName.iterator().next();
+        boolean hasNamedQualifier = bean.getQualifiers().stream()
+                .anyMatch(q -> q instanceof Named named && named.value().equals(expectedName));
+        Assertions.assertTrue(hasNamedQualifier, "Unnamed agent bean must have @Named(getName()) qualifier");
+    }
+
     private void assertBeanScope(Class<?> beanType, Class<?> scopedClass) {
         Class<? extends Annotation> scope =
                 beanManager.getBeans(beanType).iterator().next().getScope();


### PR DESCRIPTION
When a @RegisterSimpleAgent entry method was annotated with @Agent, the AgentConfigurator lambda applied tools, memory, and guardrails to the AgentBuilder but silently dropped name, description, outputKey, and async. The non-@Agent path (NonAiAgentInstance) was unaffected.

Fixes #220