### PR TITLE
fix: support marker interfaces and rename responseProviderName to ask…

### DIFF
--- a/langchain4j-cdi-a2a/README.md
+++ b/langchain4j-cdi-a2a/README.md
@@ -94,7 +94,7 @@ Bean name resolution follows the same conventions as `@RegisterAIService`:
 
 When `name` is set, the agent bean is automatically registered with that `@Named` qualifier, making it injectable by name without a separate `@Named` annotation on the interface.
 
-String attributes that support expression resolution: `name`, `description`, `outputKey`, `chatModelName`, `streamingChatModelName`, `toolProviderName`, `chatMemoryName`, `chatMemoryProviderName`, `contentRetrieverName`, `retrievalAugmentorName`, `exitConditionName`, `exitConditionDescription`, `plannerName`, `supervisorContext`, `agentListenerName`, `a2aServerUrl`, `mcpClientName`, `mcpToolName`, `responseProviderName`, and each element of `subAgentNames`.
+String attributes that support expression resolution: `name`, `description`, `outputKey`, `chatModelName`, `streamingChatModelName`, `toolProviderName`, `chatMemoryName`, `chatMemoryProviderName`, `contentRetrieverName`, `retrievalAugmentorName`, `exitConditionName`, `exitConditionDescription`, `plannerName`, `supervisorContext`, `agentListenerName`, `a2aServerUrl`, `mcpClientName`, `mcpToolName`, `askUser`, and each element of `subAgentNames`.
 
 ## Topologies
 
@@ -392,21 +392,47 @@ public interface WebSearcher {
 
 ### HUMAN_IN_THE_LOOP — `@RegisterHumanInTheLoopAgent`
 
-Pauses an agentic workflow to collect human input. A response provider bean supplies the human response.
+Pauses an agentic workflow to collect human input. The interface declares a static method that accepts a single `AgenticScope` parameter and returns a `String`. This method is called to obtain the human response.
 
 **Unique attributes:**
 
 | Attribute | Default | Description |
 |---|---|---|
-| `responseProviderName` | `""` | CDI bean name of a `Supplier<?>` or `Function<AgenticScope, ?>` that provides the human response |
+| `askUser` | `""` | Name of the static method that provides the human response. When empty, the framework selects the only matching static `String(AgenticScope)` method automatically |
 
 ```java
 @RegisterHumanInTheLoopAgent(
     name = "approval-gate",
-    responseProviderName = "humanApprovalProvider",
     outputKey = "approval")
 public interface ApprovalGate {
-    @Agent String requestApproval(@V("proposal") String proposal);
+
+    static String askUser(AgenticScope scope) {
+        // prompt the user and return their response
+        return "approved";
+    }
+
+    String requestApproval(@V("proposal") String proposal);
+}
+```
+
+When the interface declares multiple matching static methods, use `askUser` to select the right one:
+
+```java
+@RegisterHumanInTheLoopAgent(
+    name = "approval-gate",
+    askUser = "promptHuman",
+    outputKey = "approval")
+public interface ApprovalGate {
+
+    static String promptHuman(AgenticScope scope) {
+        return "approved";
+    }
+
+    static String formatMessage(AgenticScope scope) {
+        return scope.get("message").toString();
+    }
+
+    String requestApproval(@V("proposal") String proposal);
 }
 ```
 

--- a/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/aiservice/Langchain4JAIServiceBuildCompatibleExtension.java
+++ b/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/aiservice/Langchain4JAIServiceBuildCompatibleExtension.java
@@ -203,10 +203,14 @@ public class Langchain4JAIServiceBuildCompatibleExtension implements BuildCompat
             Class<? extends java.lang.annotation.Annotation> scope =
                     meta != null ? meta.scope() : jakarta.enterprise.context.ApplicationScoped.class;
 
-            builder.createWith(AIAgentCreator.class)
+            SyntheticBeanBuilder<Object> agentBuilder = builder.createWith(AIAgentCreator.class)
                     .type(interfaceClass)
                     .type(InternalAgent.class)
-                    .type(AgenticScopeOwner.class)
+                    .type(AgenticScopeOwner.class);
+            if (meta != null && meta.annotationClass() == RegisterHumanInTheLoopAgent.class) {
+                agentBuilder.type(CommonAgentCreator.HumanInTheLoopHolder.class);
+            }
+            agentBuilder
                     .type(Object.class)
                     .scope(scope)
                     .name(beanName)

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
@@ -8,7 +8,6 @@ import dev.langchain4j.agentic.agent.AgentBuilder;
 import dev.langchain4j.agentic.declarative.PlannerSupplier;
 import dev.langchain4j.agentic.internal.AgentExecutor;
 import dev.langchain4j.agentic.internal.AgentInvoker;
-import dev.langchain4j.agentic.internal.AgentSpecsProvider;
 import dev.langchain4j.agentic.internal.AgentUtil;
 import dev.langchain4j.agentic.internal.AgenticScopeOwner;
 import dev.langchain4j.agentic.internal.InternalAgent;
@@ -64,9 +63,7 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -401,24 +398,23 @@ public class CommonAgentCreator {
         return builder.build();
     }
 
-    @SuppressWarnings("unchecked")
     private static <X> X createForHumanInTheLoop(
             Instance<Object> lookup, Class<X> interfaceClass, RegisterHumanInTheLoopAgent ann) {
         HumanInTheLoop.HumanInTheLoopBuilder builder = AgenticServices.humanInTheLoopBuilder();
-        String providerName = CdiLookupHelper.resolveExpression(ann.responseProviderName());
-        if (hasText(providerName)) {
-            Object providerBean = resolveParameterizedBean(lookup, providerName, Function.class, Supplier.class);
-            if (providerBean instanceof Function fn) {
-                builder.responseProvider(fn);
-            } else if (providerBean instanceof Supplier sup) {
-                builder.responseProvider(sup);
-            } else {
-                LOGGER.log(
-                        Level.WARNING,
-                        "Response provider ''{0}'' is not resolvable as Function or Supplier, skipping",
-                        providerName);
+        String askUserMethodName = CdiLookupHelper.resolveExpression(ann.askUser());
+        Method askUserMethod = findAskUserMethodOnInterface(interfaceClass, askUserMethodName);
+        builder.responseProvider(scope -> {
+            try {
+                return askUserMethod.invoke(null, scope);
+            } catch (Exception e) {
+                Throwable cause = e instanceof java.lang.reflect.InvocationTargetException ite && ite.getCause() != null
+                        ? ite.getCause()
+                        : e;
+                if (cause instanceof RuntimeException re) throw re;
+                if (cause instanceof Error err) throw err;
+                throw new RuntimeException(cause);
             }
-        }
+        });
         String outputKey = CdiLookupHelper.resolveExpression(ann.outputKey());
         if (hasText(outputKey)) {
             builder.outputKey(outputKey);
@@ -740,7 +736,7 @@ public class CommonAgentCreator {
     }
 
     /** Marker interface allowing {@link #toAgentExecutor} to retrieve the underlying {@link HumanInTheLoop} spec. */
-    interface HumanInTheLoopHolder {
+    public interface HumanInTheLoopHolder {
         HumanInTheLoop getHumanInTheLoop();
     }
 
@@ -848,6 +844,19 @@ public class CommonAgentCreator {
         AgentAnnotationMeta meta = AgentAnnotationMeta.detect(iface);
         if (meta == null) return null;
         Method entryMethod = findEntryMethod(iface);
+        // HITL agents may be marker interfaces with no abstract method (only static methods).
+        // Even when an entry method exists, execution must go through HumanInTheLoop.askUser
+        // on the spec rather than through the user's interface method on the CDI proxy.
+        if (bean instanceof HumanInTheLoopHolder holder) {
+            HumanInTheLoop spec = holder.getHumanInTheLoop();
+            String resolvedName = meta.name();
+            String name = hasText(resolvedName)
+                    ? resolvedName
+                    : (entryMethod != null ? entryMethod.getName() : iface.getSimpleName());
+            Method askUser = findAskUserMethod();
+            AgentInvoker invoker = AgentInvoker.fromSpec(spec, askUser, name);
+            return new AgentExecutor(invoker, spec);
+        }
         if (entryMethod == null) {
             LOGGER.log(
                     Level.WARNING,
@@ -858,11 +867,6 @@ public class CommonAgentCreator {
         }
         String resolvedName = meta.name();
         String name = hasText(resolvedName) ? resolvedName : entryMethod.getName();
-        if (bean instanceof HumanInTheLoopHolder holder) {
-            AgentSpecsProvider spec = holder.getHumanInTheLoop();
-            AgentInvoker invoker = AgentInvoker.fromSpec(spec, entryMethod, name);
-            return new AgentExecutor(invoker, ia);
-        }
         String desc = meta.description();
         String outputKey = meta.outputKey();
         boolean async = meta.async();
@@ -983,6 +987,49 @@ public class CommonAgentCreator {
             }
         }
         collectInterfaces(clazz.getSuperclass(), seen);
+    }
+
+    private static Method findAskUserMethodOnInterface(Class<?> interfaceClass, String askUserMethodName) {
+        Predicate<Method> signature = m -> Modifier.isStatic(m.getModifiers())
+                && m.getParameterCount() == 1
+                && AgenticScope.class.isAssignableFrom(m.getParameterTypes()[0])
+                && String.class.equals(m.getReturnType());
+        if (hasText(askUserMethodName)) {
+            return Arrays.stream(interfaceClass.getDeclaredMethods())
+                    .filter(signature)
+                    .filter(m -> m.getName().equals(askUserMethodName))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "@RegisterHumanInTheLoopAgent interface " + interfaceClass.getName()
+                                    + " declares askUser=\"" + askUserMethodName
+                                    + "\" but no static String " + askUserMethodName
+                                    + "(AgenticScope) method was found"));
+        }
+        List<Method> candidates = Arrays.stream(interfaceClass.getDeclaredMethods())
+                .filter(signature)
+                .toList();
+        if (candidates.size() > 1) {
+            throw new IllegalArgumentException("@RegisterHumanInTheLoopAgent interface " + interfaceClass.getName()
+                    + " declares multiple static String(AgenticScope) methods ("
+                    + candidates.stream().map(Method::getName).collect(Collectors.joining(", "))
+                    + "); set the askUser attribute to select one");
+        }
+        if (candidates.isEmpty()) {
+            throw new IllegalArgumentException("@RegisterHumanInTheLoopAgent interface " + interfaceClass.getName()
+                    + " must declare a static String(AgenticScope) method to provide the human response");
+        }
+        return candidates.get(0);
+    }
+
+    private static Method findAskUserMethod() {
+        return AgentUtil.getAnnotatedMethodOnClass(HumanInTheLoop.class, Agent.class)
+                .orElseGet(() -> {
+                    try {
+                        return HumanInTheLoop.class.getMethod("askUser", AgenticScope.class);
+                    } catch (NoSuchMethodException e) {
+                        throw new IllegalStateException("HumanInTheLoop.askUser(AgenticScope) not found", e);
+                    }
+                });
     }
 
     private static Method findEntryMethod(Class<?> agentInterface) {

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterHumanInTheLoopAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterHumanInTheLoopAgent.java
@@ -30,6 +30,10 @@ public @interface RegisterHumanInTheLoopAgent {
 
     String agentListenerName() default "";
 
-    /** CDI bean name of a {@code Supplier<?>} or {@code Function<AgenticScope, ?>} that provides the human response. */
-    String responseProviderName() default "";
+    /**
+     * Name of a static method on the annotated interface that provides the human response. The method must accept a
+     * single {@code AgenticScope} parameter and return {@code String}. When empty, the framework selects the only
+     * matching static method automatically.
+     */
+    String askUser() default "";
 }

--- a/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/CommonAgentCreatorTest.java
+++ b/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/CommonAgentCreatorTest.java
@@ -12,6 +12,8 @@ import dev.langchain4j.agentic.internal.McpService;
 import dev.langchain4j.agentic.observability.AgentListener;
 import dev.langchain4j.agentic.planner.Planner;
 import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.workflow.HumanInTheLoop;
+import dev.langchain4j.cdi.agent.CommonAgentCreator.HumanInTheLoopHolder;
 import dev.langchain4j.cdi.aiservice.CdiLookupHelper;
 import dev.langchain4j.cdi.spi.RegisterA2AAgent;
 import dev.langchain4j.cdi.spi.RegisterConditionalAgent;
@@ -366,8 +368,12 @@ class CommonAgentCreatorTest {
 
     // --- Test interfaces for HUMAN_IN_THE_LOOP topology ---
     @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-    @RegisterHumanInTheLoopAgent(responseProviderName = "myProvider")
+    @RegisterHumanInTheLoopAgent
     interface HumanInTheLoopAgent {
+
+        static String askUser(AgenticScope scope) {
+            return "approved";
+        }
 
         String process(@V("input") String input);
     }
@@ -375,6 +381,59 @@ class CommonAgentCreatorTest {
     @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
     @RegisterHumanInTheLoopAgent(outputKey = "result", description = "Waits for human approval")
     interface HumanInTheLoopAgentNoProvider {
+
+        String process(@V("input") String input);
+    }
+
+    @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+    @RegisterHumanInTheLoopAgent(
+            name = "human-approval-agent",
+            description = "Asks human for approval",
+            outputKey = "approvalDecision")
+    interface HumanInTheLoopMarkerAgent {
+
+        static String askUser(AgenticScope scope) {
+            return "approved-by-marker";
+        }
+    }
+
+    @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+    @RegisterHumanInTheLoopAgent(askUser = "promptHuman")
+    interface HumanInTheLoopNamedMethod {
+
+        static String promptHuman(AgenticScope scope) {
+            return "named-response";
+        }
+
+        static String otherHelper(AgenticScope scope) {
+            return "other";
+        }
+
+        String process(@V("input") String input);
+    }
+
+    @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+    @RegisterHumanInTheLoopAgent(askUser = "nonExistent")
+    interface HumanInTheLoopBadName {
+
+        static String askUser(AgenticScope scope) {
+            return "won't match";
+        }
+
+        String process(@V("input") String input);
+    }
+
+    @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+    @RegisterHumanInTheLoopAgent
+    interface HumanInTheLoopAmbiguous {
+
+        static String methodA(AgenticScope scope) {
+            return "a";
+        }
+
+        static String methodB(AgenticScope scope) {
+            return "b";
+        }
 
         String process(@V("input") String input);
     }
@@ -983,16 +1042,9 @@ class CommonAgentCreatorTest {
     // =========================================================================
     // HUMAN_IN_THE_LOOP topology
     // =========================================================================
-    @SuppressWarnings("unchecked")
     @Test
-    void create_humanInTheLoopTopology_withSupplierProvider_buildsProxy() {
+    void create_humanInTheLoopTopology_withStaticAskUserMethod_buildsProxy() {
         Instance<Object> lookup = prepareLookups();
-        java.util.function.Supplier<String> supplier = () -> "human response";
-        Instance<java.util.function.Supplier> supplierInstance = mock(Instance.class);
-        when(lookup.select(java.util.function.Supplier.class, NamedLiteral.of("myProvider")))
-                .thenReturn(supplierInstance);
-        when(supplierInstance.isResolvable()).thenReturn(true);
-        when(supplierInstance.get()).thenReturn(supplier);
 
         HumanInTheLoopAgent agent = CommonAgentCreator.create(lookup, HumanInTheLoopAgent.class);
 
@@ -1000,44 +1052,103 @@ class CommonAgentCreatorTest {
         assertInstanceOf(InternalAgent.class, agent);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
-    void create_humanInTheLoopTopology_withFunctionProvider_buildsProxy() {
+    void create_humanInTheLoopTopology_responseProvider_invokesStaticMethod() {
         Instance<Object> lookup = prepareLookups();
-        java.util.function.Function<AgenticScope, String> fn = scope -> "human response";
-        Instance<java.util.function.Function> functionInstance = mock(Instance.class);
-        when(lookup.select(java.util.function.Function.class, NamedLiteral.of("myProvider")))
-                .thenReturn(functionInstance);
-        when(functionInstance.isResolvable()).thenReturn(true);
-        when(functionInstance.get()).thenReturn(fn);
-
         HumanInTheLoopAgent agent = CommonAgentCreator.create(lookup, HumanInTheLoopAgent.class);
+        HumanInTheLoop spec = ((HumanInTheLoopHolder) agent).getHumanInTheLoop();
+        AgenticScope scope = mock(AgenticScope.class);
 
-        assertNotNull(agent);
-        assertInstanceOf(InternalAgent.class, agent);
-        // Confirm the Function was actually retrieved from CDI and wired, not silently skipped.
-        verify(functionInstance).get();
+        Object result = spec.responseProvider().apply(scope);
+
+        assertEquals("approved", result);
     }
 
     @Test
-    void create_humanInTheLoopTopology_withNoProvider_buildsProxy() {
+    void create_humanInTheLoopTopology_namedMethod_responseProvider_invokesCorrectMethod() {
         Instance<Object> lookup = prepareLookups();
-        HumanInTheLoopAgentNoProvider agent = CommonAgentCreator.create(lookup, HumanInTheLoopAgentNoProvider.class);
+        HumanInTheLoopNamedMethod agent = CommonAgentCreator.create(lookup, HumanInTheLoopNamedMethod.class);
+        HumanInTheLoop spec = ((HumanInTheLoopHolder) agent).getHumanInTheLoop();
+        AgenticScope scope = mock(AgenticScope.class);
+
+        Object result = spec.responseProvider().apply(scope);
+
+        assertEquals("named-response", result);
+    }
+
+    @Test
+    void create_humanInTheLoopTopology_markerInterface_responseProvider_invokesStaticMethod() {
+        Instance<Object> lookup = prepareLookups();
+        HumanInTheLoopMarkerAgent agent = CommonAgentCreator.create(lookup, HumanInTheLoopMarkerAgent.class);
+        HumanInTheLoop spec = ((HumanInTheLoopHolder) agent).getHumanInTheLoop();
+        AgenticScope scope = mock(AgenticScope.class);
+
+        Object result = spec.responseProvider().apply(scope);
+
+        assertEquals("approved-by-marker", result);
+    }
+
+    @Test
+    void create_humanInTheLoopTopology_withNoProvider_throws() {
+        Instance<Object> lookup = prepareLookups();
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> CommonAgentCreator.create(lookup, HumanInTheLoopAgentNoProvider.class));
+        assertTrue(ex.getMessage().contains("must declare a static String(AgenticScope) method"));
+    }
+
+    @Test
+    void create_humanInTheLoopTopology_markerInterface_buildsProxy() {
+        Instance<Object> lookup = prepareLookups();
+        HumanInTheLoopMarkerAgent agent = CommonAgentCreator.create(lookup, HumanInTheLoopMarkerAgent.class);
 
         assertNotNull(agent);
         assertInstanceOf(InternalAgent.class, agent);
+        InternalAgent ia = (InternalAgent) agent;
+        assertEquals("human-approval-agent", ia.name());
+        assertEquals("Asks human for approval", ia.description());
+        assertEquals("approvalDecision", ia.outputKey());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
-    void toAgentExecutor_humanInTheLoopProxy_returnsAgentExecutor() {
+    void toAgentExecutor_humanInTheLoopMarkerInterface_returnsAgentExecutor() {
         Instance<Object> lookup = prepareLookups();
-        HumanInTheLoopAgentNoProvider proxy = CommonAgentCreator.create(lookup, HumanInTheLoopAgentNoProvider.class);
+        HumanInTheLoopMarkerAgent proxy = CommonAgentCreator.create(lookup, HumanInTheLoopMarkerAgent.class);
         assertInstanceOf(InternalAgent.class, proxy);
 
         Object result = CommonAgentCreator.toAgentExecutor(proxy);
 
         assertInstanceOf(AgentExecutor.class, result);
+        assertEquals("human-approval-agent", ((InternalAgent) result).name());
+    }
+
+    @Test
+    void create_humanInTheLoopTopology_namedAskUser_buildsProxy() {
+        Instance<Object> lookup = prepareLookups();
+
+        HumanInTheLoopNamedMethod agent = CommonAgentCreator.create(lookup, HumanInTheLoopNamedMethod.class);
+
+        assertNotNull(agent);
+        assertInstanceOf(InternalAgent.class, agent);
+    }
+
+    @Test
+    void create_humanInTheLoopTopology_badName_throws() {
+        Instance<Object> lookup = prepareLookups();
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class, () -> CommonAgentCreator.create(lookup, HumanInTheLoopBadName.class));
+        assertTrue(ex.getMessage().contains("nonExistent"));
+    }
+
+    @Test
+    void create_humanInTheLoopTopology_ambiguous_throws() {
+        Instance<Object> lookup = prepareLookups();
+
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class, () -> CommonAgentCreator.create(lookup, HumanInTheLoopAmbiguous.class));
+        assertTrue(ex.getMessage().contains("askUser"));
     }
 
     // =========================================================================

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/pom.xml
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/pom.xml
@@ -22,5 +22,9 @@
             <groupId>dev.langchain4j.cdi</groupId>
             <artifactId>langchain4j-cdi-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-agentic</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/HumanInTheLoopEntryMethodAgentService.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/HumanInTheLoopEntryMethodAgentService.java
@@ -1,0 +1,19 @@
+package dev.langchain4j.cdi.integrationtests;
+
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.cdi.spi.RegisterHumanInTheLoopAgent;
+import dev.langchain4j.service.V;
+
+@SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+@RegisterHumanInTheLoopAgent(
+        name = "hitl-entry-method-agent",
+        description = "Entry-method HITL agent for integration testing",
+        outputKey = "entryMethodResult")
+public interface HumanInTheLoopEntryMethodAgentService {
+
+    static String askUser(AgenticScope scope) {
+        return "entry-method-response";
+    }
+
+    String process(@V("input") String input);
+}

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/HumanInTheLoopMarkerAgentService.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/HumanInTheLoopMarkerAgentService.java
@@ -1,0 +1,16 @@
+package dev.langchain4j.cdi.integrationtests;
+
+import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.cdi.spi.RegisterHumanInTheLoopAgent;
+
+@SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+@RegisterHumanInTheLoopAgent(
+        name = "hitl-marker-agent",
+        description = "Marker interface HITL agent for integration testing",
+        outputKey = "markerResult")
+public interface HumanInTheLoopMarkerAgentService {
+
+    static String askUser(AgenticScope scope) {
+        return "marker-response";
+    }
+}

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/main/java/dev/langchain4j/cdi/core/integrationtests/HumanInTheLoopRestService.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/main/java/dev/langchain4j/cdi/core/integrationtests/HumanInTheLoopRestService.java
@@ -1,0 +1,32 @@
+package dev.langchain4j.cdi.core.integrationtests;
+
+import dev.langchain4j.cdi.integrationtests.HumanInTheLoopEntryMethodAgentService;
+import dev.langchain4j.cdi.integrationtests.HumanInTheLoopMarkerAgentService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/hitl-agent")
+@Produces(MediaType.TEXT_PLAIN)
+public class HumanInTheLoopRestService {
+
+    @Inject
+    HumanInTheLoopMarkerAgentService markerAgent;
+
+    @Inject
+    HumanInTheLoopEntryMethodAgentService entryMethodAgent;
+
+    @GET
+    @Path("/marker")
+    public String markerAgentInfo() {
+        return markerAgent.toString();
+    }
+
+    @GET
+    @Path("/entry-method")
+    public String entryMethodAgentInfo() {
+        return entryMethodAgent.toString();
+    }
+}

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/test/java/dev/langchain4j/cdi/core/integrationtests/QuarkusHumanInTheLoopIntegrationTest.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/test/java/dev/langchain4j/cdi/core/integrationtests/QuarkusHumanInTheLoopIntegrationTest.java
@@ -1,0 +1,41 @@
+package dev.langchain4j.cdi.core.integrationtests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class QuarkusHumanInTheLoopIntegrationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-port")
+    int port;
+
+    @Test
+    public void testMarkerAgentIsInjectableWithCorrectName() {
+        try (Client client = ClientBuilder.newClient()) {
+            WebTarget target = client.target("http://localhost:" + port + "/hitl-agent/marker");
+            Response response = target.request(MediaType.TEXT_PLAIN).get();
+
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(response.readEntity(String.class)).isEqualTo("Agent[hitl-marker-agent]");
+        }
+    }
+
+    @Test
+    public void testEntryMethodAgentIsInjectableWithCorrectName() {
+        try (Client client = ClientBuilder.newClient()) {
+            WebTarget target = client.target("http://localhost:" + port + "/hitl-agent/entry-method");
+            Response response = target.request(MediaType.TEXT_PLAIN).get();
+
+            assertThat(response.getStatus()).isEqualTo(200);
+            assertThat(response.readEntity(String.class)).isEqualTo("Agent[hitl-entry-method-agent]");
+        }
+    }
+}

--- a/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/LangChain4JAIAgentBean.java
+++ b/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/LangChain4JAIAgentBean.java
@@ -5,6 +5,7 @@ import dev.langchain4j.agentic.internal.InternalAgent;
 import dev.langchain4j.cdi.agent.AgentAnnotationMeta;
 import dev.langchain4j.cdi.agent.CommonAgentCreator;
 import dev.langchain4j.cdi.aiservice.CdiLookupHelper;
+import dev.langchain4j.cdi.spi.RegisterHumanInTheLoopAgent;
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Default;
@@ -73,6 +74,9 @@ public class LangChain4JAIAgentBean<T> implements Bean<T>, PassivationCapable {
         types.add(agentInterfaceClass);
         types.add(InternalAgent.class);
         types.add(AgenticScopeOwner.class);
+        if (stereotypeAnnotationClass == RegisterHumanInTheLoopAgent.class) {
+            types.add(CommonAgentCreator.HumanInTheLoopHolder.class);
+        }
         types.add(Object.class);
         return Collections.unmodifiableSet(types);
     }


### PR DESCRIPTION
…UserName in @RegisterHumanInTheLoopAgent

- HITL agents no longer require an entry method — marker interfaces with only static methods now route through HumanInTheLoop.askUser directly
- Rename responseProviderName to askUserName for clarity; it still accepts a Supplier<?> or Function<AgenticScope, ?> CDI bean by name
- Unit and integration tests for marker interface and entry-method paths

Fixes #222