### PR TITLE
fix: Missing AgenticScopeOwner for some agents

### DIFF
--- a/examples/car-booking-mcp/pom.xml
+++ b/examples/car-booking-mcp/pom.xml
@@ -66,7 +66,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${version.compiler.plugin}</version>
-                <configuration />
+                <configuration/>
             </plugin>
 
             <!--Build configuration for the WAR plugin: -->

--- a/examples/liberty-car-booking-mcp/pom.xml
+++ b/examples/liberty-car-booking-mcp/pom.xml
@@ -24,8 +24,8 @@
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <war-plugin.version>3.4.0</war-plugin.version>
         <!-- We need only javac to use the release parameter. OpenLiberty doesn't depend on maven-compiler-plugin.' -->
-        <maven.compiler.source combine.self="override" />
-        <maven.compiler.target combine.self="override" />
+        <maven.compiler.source combine.self="override"/>
+        <maven.compiler.target combine.self="override"/>
 
         <version.io.smallrye.fault-tolerance>6.7.3</version.io.smallrye.fault-tolerance>
         <!--Strictly for OpenLiberty-->

--- a/examples/liberty-car-booking/pom.xml
+++ b/examples/liberty-car-booking/pom.xml
@@ -24,8 +24,8 @@
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <war-plugin.version>3.4.0</war-plugin.version>
         <!-- We need only javac to use the release parameter. OpenLiberty doesn't depend on maven-compiler-plugin.' -->
-        <maven.compiler.source combine.self="override" />
-        <maven.compiler.target combine.self="override" />
+        <maven.compiler.source combine.self="override"/>
+        <maven.compiler.target combine.self="override"/>
 
         <version.io.smallrye.fault-tolerance>6.7.3</version.io.smallrye.fault-tolerance>
         <!--Strictly for OpenLiberty-->

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
@@ -197,7 +197,7 @@ public class CommonAgentCreator {
             // Simple AI-service agents have no planner scope. When AgentExecutor calls
             // withAgenticScope() via the Weld scope proxy (which now exposes AgenticScopeOwner),
             // return this proxy unchanged so execution continues without binding a child scope.
-            if (declaringClass.isAssignableFrom(AgenticScopeOwner.class)) {
+            if (AgenticScopeOwner.class.isAssignableFrom(declaringClass)) {
                 return method.getName().equals("withAgenticScope") ? proxy : null;
             }
             return method.invoke(aiService, args);
@@ -353,7 +353,7 @@ public class CommonAgentCreator {
             throw new IllegalArgumentException(
                     "@RegisterA2AAgent on " + interfaceClass.getSimpleName() + ": 'a2aServerUrl' is required.");
         }
-        return loadA2ABuilder()
+        X a2aAgent = loadA2ABuilder()
                 .build(
                         interfaceClass,
                         url,
@@ -361,6 +361,7 @@ public class CommonAgentCreator {
                         ann.async(),
                         ann.agentListenerName(),
                         lookup);
+        return wrapWithAgenticScope(interfaceClass, a2aAgent);
     }
 
     private static <X> X createForMcpClient(
@@ -395,7 +396,7 @@ public class CommonAgentCreator {
         if (listener != null) {
             builder.listener(listener);
         }
-        return builder.build();
+        return wrapWithAgenticScope(interfaceClass, builder.build());
     }
 
     private static <X> X createForHumanInTheLoop(
@@ -448,13 +449,29 @@ public class CommonAgentCreator {
             if (declaringClass.isAssignableFrom(InternalAgent.class)) {
                 return method.invoke(agentInstance, args);
             }
+            if (AgenticScopeOwner.class.isAssignableFrom(declaringClass)) {
+                return method.getName().equals("withAgenticScope") ? proxy : null;
+            }
             throw new UnsupportedOperationException(
                     "HUMAN_IN_THE_LOOP agents must be invoked through the agentic system");
         };
         return (X) java.lang.reflect.Proxy.newProxyInstance(
                 interfaceClass.getClassLoader(),
-                new Class<?>[] {interfaceClass, InternalAgent.class, HumanInTheLoopHolder.class},
+                new Class<?>[] {interfaceClass, InternalAgent.class, AgenticScopeOwner.class, HumanInTheLoopHolder.class
+                },
                 handler);
+    }
+
+    /** Wraps a delegate agent proxy so the result implements {@link AgenticScopeOwner}. */
+    private static <X> X wrapWithAgenticScope(Class<X> interfaceClass, X delegate) {
+        InvocationHandler handler = (proxy, method, args) -> {
+            Class<?> declaringClass = method.getDeclaringClass();
+            if (AgenticScopeOwner.class.isAssignableFrom(declaringClass)) {
+                return method.getName().equals("withAgenticScope") ? proxy : null;
+            }
+            return method.invoke(delegate, args);
+        };
+        return AgentUtil.buildAgent(interfaceClass, handler);
     }
 
     // =========================================================================

--- a/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/CommonAgentCreatorTest.java
+++ b/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/CommonAgentCreatorTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.internal.AgentExecutor;
+import dev.langchain4j.agentic.internal.AgenticScopeOwner;
 import dev.langchain4j.agentic.internal.InternalAgent;
 import dev.langchain4j.agentic.internal.McpClientBuilder;
 import dev.langchain4j.agentic.internal.McpService;
@@ -1003,9 +1004,14 @@ class CommonAgentCreatorTest {
 
             McpClientAgentWithInputKeys agent = CommonAgentCreator.create(lookup, McpClientAgentWithInputKeys.class);
 
-            assertSame(mockProxy, agent);
+            assertNotNull(agent);
+            assertInstanceOf(InternalAgent.class, agent);
+            assertInstanceOf(AgenticScopeOwner.class, agent);
             verify(mcpBuilder).toolName("web_search");
             verify(mcpBuilder).inputKeys("query", "locale");
+
+            when(mockProxy.process("hello")).thenReturn("delegated");
+            assertEquals("delegated", agent.process("hello"));
         }
     }
 
@@ -1034,8 +1040,13 @@ class CommonAgentCreatorTest {
 
             McpClientAgentAsync agent = CommonAgentCreator.create(lookup, McpClientAgentAsync.class);
 
-            assertSame(mockProxy, agent);
+            assertNotNull(agent);
+            assertInstanceOf(InternalAgent.class, agent);
+            assertInstanceOf(AgenticScopeOwner.class, agent);
             verify(mcpBuilder).async(true);
+
+            when(mockProxy.process("test")).thenReturn("async-delegated");
+            assertEquals("async-delegated", agent.process("test"));
         }
     }
 
@@ -1105,6 +1116,7 @@ class CommonAgentCreatorTest {
 
         assertNotNull(agent);
         assertInstanceOf(InternalAgent.class, agent);
+        assertInstanceOf(AgenticScopeOwner.class, agent);
         InternalAgent ia = (InternalAgent) agent;
         assertEquals("human-approval-agent", ia.name());
         assertEquals("Asks human for approval", ia.description());
@@ -1131,6 +1143,7 @@ class CommonAgentCreatorTest {
 
         assertNotNull(agent);
         assertInstanceOf(InternalAgent.class, agent);
+        assertInstanceOf(AgenticScopeOwner.class, agent);
     }
 
     @Test


### PR DESCRIPTION
A2A, MCP Client, and Human-in-the-Loop agent proxies did not implement AgenticScopeOwner, causing IllegalArgumentException when Weld's client proxy delegated withAgenticScope(). Also fix a reversed isAssignableFrom check in the SIMPLE agent proxy.