### PR TITLE
feature: Add optional and summarizedContext attributes to all agent a…

### DIFF
--- a/langchain4j-cdi-a2a/src/main/java/dev/langchain4j/cdi/agent/a2a/DefaultA2AAgentBuilder.java
+++ b/langchain4j-cdi-a2a/src/main/java/dev/langchain4j/cdi/agent/a2a/DefaultA2AAgentBuilder.java
@@ -15,6 +15,7 @@ public class DefaultA2AAgentBuilder implements A2AAgentBuilder {
             String url,
             String outputKey,
             boolean async,
+            boolean optional,
             String agentListenerName,
             Instance<Object> lookup) {
         // Defensive: createForA2A already validates the URL before calling this builder,

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/AgentAnnotationMeta.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/AgentAnnotationMeta.java
@@ -13,6 +13,7 @@ import dev.langchain4j.cdi.spi.RegisterSequenceAgent;
 import dev.langchain4j.cdi.spi.RegisterSimpleAgent;
 import dev.langchain4j.cdi.spi.RegisterSupervisorAgent;
 import java.lang.annotation.Annotation;
+import java.util.Arrays;
 
 /**
  * Extracts CDI metadata from any of the 11 agent stereotype annotations: {@link RegisterSimpleAgent},
@@ -29,6 +30,17 @@ import java.lang.annotation.Annotation;
  * <p><b>API note:</b> this record is part of the stable public API of {@code langchain4j-cdi-core}, alongside the
  * annotations in {@code dev.langchain4j.cdi.spi}. It lives in the {@code dev.langchain4j.cdi.agent} package for
  * historical reasons; treat it as public and stable.
+ *
+ * @param scope the CDI scope annotation class (e.g. {@code ApplicationScoped.class})
+ * @param rawName the agent name before expression resolution
+ * @param rawDescription the agent description before expression resolution
+ * @param rawOutputKey the output key before expression resolution
+ * @param async whether the agent executes asynchronously
+ * @param optional when {@code true} the agent's execution is silently skipped if any of its arguments is missing in the
+ *     agentic scope, instead of failing the entire agentic system
+ * @param rawSummarizedContext names of other agents whose conversation context should be summarized and injected into
+ *     this agent's prompt, before expression resolution
+ * @param annotationClass the concrete stereotype annotation class that was detected
  */
 public record AgentAnnotationMeta(
         Class<? extends Annotation> scope,
@@ -36,6 +48,8 @@ public record AgentAnnotationMeta(
         String rawDescription,
         String rawOutputKey,
         boolean async,
+        boolean optional,
+        String[] rawSummarizedContext,
         Class<? extends Annotation> annotationClass) {
 
     /**
@@ -61,17 +75,33 @@ public record AgentAnnotationMeta(
                     simple.description(),
                     simple.outputKey(),
                     simple.async(),
+                    simple.optional(),
+                    simple.summarizedContext(),
                     RegisterSimpleAgent.class);
 
         RegisterSequenceAgent seq = interfaceClass.getAnnotation(RegisterSequenceAgent.class);
         if (seq != null)
             return new AgentAnnotationMeta(
-                    seq.scope(), seq.name(), seq.description(), seq.outputKey(), false, RegisterSequenceAgent.class);
+                    seq.scope(),
+                    seq.name(),
+                    seq.description(),
+                    seq.outputKey(),
+                    false,
+                    seq.optional(),
+                    seq.summarizedContext(),
+                    RegisterSequenceAgent.class);
 
         RegisterLoopAgent loop = interfaceClass.getAnnotation(RegisterLoopAgent.class);
         if (loop != null)
             return new AgentAnnotationMeta(
-                    loop.scope(), loop.name(), loop.description(), loop.outputKey(), false, RegisterLoopAgent.class);
+                    loop.scope(),
+                    loop.name(),
+                    loop.description(),
+                    loop.outputKey(),
+                    false,
+                    loop.optional(),
+                    loop.summarizedContext(),
+                    RegisterLoopAgent.class);
 
         RegisterParallelAgent parallel = interfaceClass.getAnnotation(RegisterParallelAgent.class);
         if (parallel != null)
@@ -81,6 +111,8 @@ public record AgentAnnotationMeta(
                     parallel.description(),
                     parallel.outputKey(),
                     false,
+                    parallel.optional(),
+                    parallel.summarizedContext(),
                     RegisterParallelAgent.class);
 
         RegisterParallelMapperAgent mapper = interfaceClass.getAnnotation(RegisterParallelMapperAgent.class);
@@ -91,6 +123,8 @@ public record AgentAnnotationMeta(
                     mapper.description(),
                     mapper.outputKey(),
                     false,
+                    mapper.optional(),
+                    mapper.summarizedContext(),
                     RegisterParallelMapperAgent.class);
 
         RegisterConditionalAgent cond = interfaceClass.getAnnotation(RegisterConditionalAgent.class);
@@ -101,6 +135,8 @@ public record AgentAnnotationMeta(
                     cond.description(),
                     cond.outputKey(),
                     false,
+                    cond.optional(),
+                    cond.summarizedContext(),
                     RegisterConditionalAgent.class);
 
         RegisterSupervisorAgent supervisor = interfaceClass.getAnnotation(RegisterSupervisorAgent.class);
@@ -111,6 +147,8 @@ public record AgentAnnotationMeta(
                     supervisor.description(),
                     supervisor.outputKey(),
                     false,
+                    supervisor.optional(),
+                    supervisor.summarizedContext(),
                     RegisterSupervisorAgent.class);
 
         RegisterPlannerAgent planner = interfaceClass.getAnnotation(RegisterPlannerAgent.class);
@@ -121,12 +159,21 @@ public record AgentAnnotationMeta(
                     planner.description(),
                     planner.outputKey(),
                     false,
+                    planner.optional(),
+                    planner.summarizedContext(),
                     RegisterPlannerAgent.class);
 
         RegisterA2AAgent a2a = interfaceClass.getAnnotation(RegisterA2AAgent.class);
         if (a2a != null)
             return new AgentAnnotationMeta(
-                    a2a.scope(), a2a.name(), a2a.description(), a2a.outputKey(), a2a.async(), RegisterA2AAgent.class);
+                    a2a.scope(),
+                    a2a.name(),
+                    a2a.description(),
+                    a2a.outputKey(),
+                    a2a.async(),
+                    a2a.optional(),
+                    a2a.summarizedContext(),
+                    RegisterA2AAgent.class);
 
         RegisterMcpClientAgent mcp = interfaceClass.getAnnotation(RegisterMcpClientAgent.class);
         if (mcp != null)
@@ -136,6 +183,8 @@ public record AgentAnnotationMeta(
                     mcp.description(),
                     mcp.outputKey(),
                     mcp.async(),
+                    mcp.optional(),
+                    mcp.summarizedContext(),
                     RegisterMcpClientAgent.class);
 
         RegisterHumanInTheLoopAgent hitl = interfaceClass.getAnnotation(RegisterHumanInTheLoopAgent.class);
@@ -146,6 +195,8 @@ public record AgentAnnotationMeta(
                     hitl.description(),
                     hitl.outputKey(),
                     hitl.async(),
+                    hitl.optional(),
+                    hitl.summarizedContext(),
                     RegisterHumanInTheLoopAgent.class);
 
         return null;
@@ -171,5 +222,18 @@ public record AgentAnnotationMeta(
     /** Expression-resolved output key, equivalent to the annotation's {@code outputKey()} after EL/Config expansion. */
     public String outputKey() {
         return CdiLookupHelper.resolveExpression(rawOutputKey);
+    }
+
+    /**
+     * Expression-resolved summarized context agent names, equivalent to the annotation's {@code summarizedContext()}
+     * after EL/Config expansion on each element.
+     */
+    public String[] summarizedContext() {
+        if (rawSummarizedContext == null || rawSummarizedContext.length == 0) {
+            return new String[0];
+        }
+        return Arrays.stream(rawSummarizedContext)
+                .map(CdiLookupHelper::resolveExpression)
+                .toArray(String[]::new);
     }
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
@@ -161,6 +161,8 @@ public class CommonAgentCreator {
                                     builder.outputKey(resolvedOutputKey);
                                 }
                                 builder.async(ann.async());
+                                builder.optional(ann.optional());
+                                applySummarizedContext(builder::summarizedContext, ann.summarizedContext());
                                 applyListener(builder::listener, ann.agentListenerName(), lookup);
                             },
                             agentClass -> {
@@ -176,7 +178,7 @@ public class CommonAgentCreator {
         if (!hasText(outputKey)) outputKey = "";
         AgentListener listener = CdiLookupHelper.resolveSingle(lookup, AgentListener.class, ann.agentListenerName());
         NonAiAgentInstance agentInstance = buildNonAiAgentInstance(
-                interfaceClass, entryMethod, ann.name(), description, outputKey, ann.async(), listener);
+                interfaceClass, entryMethod, ann.name(), description, outputKey, ann.async(), ann.optional(), listener);
         InvocationHandler handler = (proxy, method, args) -> {
             Class<?> declaringClass = method.getDeclaringClass();
             if (declaringClass == Object.class) {
@@ -359,6 +361,7 @@ public class CommonAgentCreator {
                         url,
                         CdiLookupHelper.resolveExpression(ann.outputKey()),
                         ann.async(),
+                        ann.optional(),
                         ann.agentListenerName(),
                         lookup);
         return wrapWithAgenticScope(interfaceClass, a2aAgent);
@@ -432,7 +435,7 @@ public class CommonAgentCreator {
         HumanInTheLoop spec = builder.build();
         Method entryMethod = findEntryMethod(interfaceClass);
         NonAiAgentInstance agentInstance = buildNonAiAgentInstance(
-                interfaceClass, entryMethod, ann.name(), description, outputKey, ann.async(), listener);
+                interfaceClass, entryMethod, ann.name(), description, outputKey, ann.async(), ann.optional(), listener);
         InvocationHandler handler = (proxy, method, args) -> {
             Class<?> declaringClass = method.getDeclaringClass();
             if (declaringClass == Object.class) {
@@ -494,12 +497,24 @@ public class CommonAgentCreator {
             String description,
             String outputKey,
             boolean async,
+            boolean optional,
             AgentListener listener) {
         String name = CdiLookupHelper.resolveExpression(rawName);
         if (!hasText(name)) {
             name = entryMethod != null ? entryMethod.getName() : interfaceClass.getSimpleName();
         }
         List<AgentArgument> arguments = entryMethod != null ? AgentUtil.argumentsFromMethod(entryMethod) : List.of();
+        if (optional) {
+            return new OptionalNonAiAgentInstance(
+                    interfaceClass,
+                    name,
+                    description,
+                    entryMethod != null ? entryMethod.getGenericReturnType() : String.class,
+                    outputKey,
+                    async,
+                    arguments,
+                    listener);
+        }
         return new NonAiAgentInstance(
                 interfaceClass,
                 name,
@@ -509,6 +524,32 @@ public class CommonAgentCreator {
                 async,
                 arguments,
                 listener);
+    }
+
+    /**
+     * Extends {@link NonAiAgentInstance} to override {@link #optional()} so that non-AI agent proxies can report
+     * themselves as optional. The upstream class does not expose an {@code optional} field; its
+     * {@link dev.langchain4j.agentic.planner.AgentInstance#optional() AgentInstance.optional()} default returns
+     * {@code false}.
+     */
+    private static class OptionalNonAiAgentInstance extends NonAiAgentInstance {
+
+        OptionalNonAiAgentInstance(
+                Class<?> type,
+                String name,
+                String description,
+                java.lang.reflect.Type outputType,
+                String outputKey,
+                boolean async,
+                List<AgentArgument> arguments,
+                AgentListener listener) {
+            super(type, name, description, outputType, outputKey, async, arguments, listener);
+        }
+
+        @Override
+        public boolean optional() {
+            return true;
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -565,6 +606,19 @@ public class CommonAgentCreator {
         AgentListener listener = CdiLookupHelper.resolveSingle(lookup, AgentListener.class, agentListenerName);
         if (listener != null) {
             setter.accept(listener);
+        }
+    }
+
+    private static void applySummarizedContext(Consumer<String[]> setter, String[] rawSummarizedContext) {
+        if (rawSummarizedContext == null || rawSummarizedContext.length == 0) {
+            return;
+        }
+        String[] resolved = Arrays.stream(rawSummarizedContext)
+                .map(CdiLookupHelper::resolveExpression)
+                .filter(s -> hasText(s))
+                .toArray(String[]::new);
+        if (resolved.length > 0) {
+            setter.accept(resolved);
         }
     }
 
@@ -887,7 +941,16 @@ public class CommonAgentCreator {
         String desc = meta.description();
         String outputKey = meta.outputKey();
         boolean async = meta.async();
-        AgentInvoker invoker = AgentUtil.nonAiAgentInvoker(entryMethod, name, desc, outputKey, async);
+        boolean optional = meta.optional();
+        AgentInvoker invoker;
+        if (optional) {
+            List<AgentArgument> arguments = AgentUtil.argumentsFromMethod(entryMethod);
+            NonAiAgentInstance agent = new OptionalNonAiAgentInstance(
+                    iface, name, desc, entryMethod.getGenericReturnType(), outputKey, async, arguments, null);
+            invoker = AgentInvoker.fromMethod(agent, entryMethod);
+        } else {
+            invoker = AgentUtil.nonAiAgentInvoker(entryMethod, name, desc, outputKey, async);
+        }
         return new AgentExecutor(invoker, ia);
     }
 

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/spi/A2AAgentBuilder.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/spi/A2AAgentBuilder.java
@@ -8,12 +8,53 @@ import jakarta.enterprise.inject.Instance;
  */
 public interface A2AAgentBuilder {
 
-    /** Build an A2A agent from individual field values. */
+    /**
+     * Build an A2A agent from individual field values.
+     *
+     * <p>Delegates to {@link #build(Class, String, String, boolean, boolean, String, Instance)} with {@code optional}
+     * set to {@code false}.
+     *
+     * @param <X> the agent interface type
+     * @param interfaceClass the agent interface class
+     * @param url the A2A server URL
+     * @param outputKey the key under which the agent stores its output in the agentic scope, or blank to skip
+     * @param async whether the agent executes asynchronously
+     * @param agentListenerName CDI bean name of the {@link dev.langchain4j.agentic.observability.AgentListener}, or
+     *     blank for none
+     * @param lookup CDI lookup instance for resolving named beans
+     * @return a proxy implementing {@code interfaceClass} that delegates to the remote A2A server
+     */
+    default <X> X build(
+            Class<X> interfaceClass,
+            String url,
+            String outputKey,
+            boolean async,
+            String agentListenerName,
+            Instance<Object> lookup) {
+        return build(interfaceClass, url, outputKey, async, false, agentListenerName, lookup);
+    }
+
+    /**
+     * Build an A2A agent from individual field values including the optional flag.
+     *
+     * @param <X> the agent interface type
+     * @param interfaceClass the agent interface class
+     * @param url the A2A server URL
+     * @param outputKey the key under which the agent stores its output in the agentic scope, or blank to skip
+     * @param async whether the agent executes asynchronously
+     * @param optional when {@code true} the agent's execution is silently skipped if any of its arguments is missing in
+     *     the agentic scope, instead of failing the entire agentic system
+     * @param agentListenerName CDI bean name of the {@link dev.langchain4j.agentic.observability.AgentListener}, or
+     *     blank for none
+     * @param lookup CDI lookup instance for resolving named beans
+     * @return a proxy implementing {@code interfaceClass} that delegates to the remote A2A server
+     */
     <X> X build(
             Class<X> interfaceClass,
             String url,
             String outputKey,
             boolean async,
+            boolean optional,
             String agentListenerName,
             Instance<Object> lookup);
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterA2AAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterA2AAgent.java
@@ -31,6 +31,15 @@ public @interface RegisterA2AAgent {
 
     boolean async() default false;
 
+    /**
+     * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
+     * scope, instead of making the agentic system's execution fail.
+     */
+    boolean optional() default false;
+
+    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    String[] summarizedContext() default {};
+
     String agentListenerName() default "";
 
     /** URL of the A2A server. Required. */

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterAIService.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterAIService.java
@@ -11,9 +11,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-@Retention(RUNTIME)
-@Target(ElementType.TYPE)
-@Stereotype
 /**
  * Stereotype to register an interface as a LangChain4j AI Service.
  *
@@ -21,6 +18,9 @@ import java.lang.annotation.Target;
  * reference named CDI beans to wire the service: models, retrievers, tools, memories, etc. If a property name is blank,
  * the dependency is ignored. For chatModelName, "#default" means select the default bean.
  */
+@Retention(RUNTIME)
+@Target(ElementType.TYPE)
+@Stereotype
 public @interface RegisterAIService {
 
     Class<? extends Annotation> scope() default RequestScoped.class;

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterConditionalAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterConditionalAgent.java
@@ -25,6 +25,15 @@ public @interface RegisterConditionalAgent {
 
     String outputKey() default "";
 
+    /**
+     * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
+     * scope, instead of making the agentic system's execution fail.
+     */
+    boolean optional() default false;
+
+    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    String[] summarizedContext() default {};
+
     String agentListenerName() default "";
 
     String[] subAgentNames() default {};

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterHumanInTheLoopAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterHumanInTheLoopAgent.java
@@ -28,6 +28,15 @@ public @interface RegisterHumanInTheLoopAgent {
 
     boolean async() default false;
 
+    /**
+     * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
+     * scope, instead of making the agentic system's execution fail.
+     */
+    boolean optional() default false;
+
+    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    String[] summarizedContext() default {};
+
     String agentListenerName() default "";
 
     /**

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterLoopAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterLoopAgent.java
@@ -23,6 +23,15 @@ public @interface RegisterLoopAgent {
 
     String outputKey() default "";
 
+    /**
+     * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
+     * scope, instead of making the agentic system's execution fail.
+     */
+    boolean optional() default false;
+
+    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    String[] summarizedContext() default {};
+
     String agentListenerName() default "";
 
     String[] subAgentNames() default {};

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterMcpClientAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterMcpClientAgent.java
@@ -29,6 +29,15 @@ public @interface RegisterMcpClientAgent {
 
     boolean async() default false;
 
+    /**
+     * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
+     * scope, instead of making the agentic system's execution fail.
+     */
+    boolean optional() default false;
+
+    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    String[] summarizedContext() default {};
+
     String agentListenerName() default "";
 
     /** CDI bean name of the MCP client object. Required. */

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterParallelAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterParallelAgent.java
@@ -23,6 +23,15 @@ public @interface RegisterParallelAgent {
 
     String outputKey() default "";
 
+    /**
+     * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
+     * scope, instead of making the agentic system's execution fail.
+     */
+    boolean optional() default false;
+
+    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    String[] summarizedContext() default {};
+
     String agentListenerName() default "";
 
     String[] subAgentNames() default {};

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterParallelMapperAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterParallelMapperAgent.java
@@ -29,6 +29,15 @@ public @interface RegisterParallelMapperAgent {
 
     String outputKey() default "";
 
+    /**
+     * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
+     * scope, instead of making the agentic system's execution fail.
+     */
+    boolean optional() default false;
+
+    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    String[] summarizedContext() default {};
+
     String agentListenerName() default "";
 
     String[] subAgentNames() default {};

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterPlannerAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterPlannerAgent.java
@@ -29,6 +29,15 @@ public @interface RegisterPlannerAgent {
 
     String outputKey() default "";
 
+    /**
+     * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
+     * scope, instead of making the agentic system's execution fail.
+     */
+    boolean optional() default false;
+
+    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    String[] summarizedContext() default {};
+
     String agentListenerName() default "";
 
     String[] subAgentNames() default {};

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSequenceAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSequenceAgent.java
@@ -23,6 +23,15 @@ public @interface RegisterSequenceAgent {
 
     String outputKey() default "";
 
+    /**
+     * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
+     * scope, instead of making the agentic system's execution fail.
+     */
+    boolean optional() default false;
+
+    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    String[] summarizedContext() default {};
+
     String agentListenerName() default "";
 
     String[] subAgentNames() default {};

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSimpleAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSimpleAgent.java
@@ -33,6 +33,15 @@ public @interface RegisterSimpleAgent {
 
     boolean async() default false;
 
+    /**
+     * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
+     * scope, instead of making the agentic system's execution fail.
+     */
+    boolean optional() default false;
+
+    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    String[] summarizedContext() default {};
+
     String agentListenerName() default "";
 
     String chatModelName() default "#default";

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSupervisorAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSupervisorAgent.java
@@ -25,6 +25,15 @@ public @interface RegisterSupervisorAgent {
 
     String outputKey() default "";
 
+    /**
+     * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
+     * scope, instead of making the agentic system's execution fail.
+     */
+    boolean optional() default false;
+
+    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    String[] summarizedContext() default {};
+
     String agentListenerName() default "";
 
     String[] subAgentNames() default {};

--- a/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/AgentAnnotationMetaTest.java
+++ b/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/AgentAnnotationMetaTest.java
@@ -69,6 +69,19 @@ class AgentAnnotationMetaTest {
     @RegisterHumanInTheLoopAgent(name = "hitl", description = "hitl desc", outputKey = "hitlOut", async = true)
     interface HumanInTheLoopInterface {}
 
+    @RegisterSimpleAgent(
+            name = "optSimple",
+            description = "optional simple",
+            optional = true,
+            summarizedContext = {"agentA", "agentB"})
+    interface OptionalSimpleInterface {}
+
+    @RegisterSequenceAgent(
+            name = "optSeq",
+            optional = true,
+            summarizedContext = {"writer"})
+    interface OptionalSequenceInterface {}
+
     interface PlainInterface {}
 
     // =========================================================================
@@ -257,5 +270,72 @@ class AgentAnnotationMetaTest {
     @Test
     void isAgentInterface_annotatedClass_returnsFalse() {
         assertFalse(AgentAnnotationMeta.isAgentInterface(Object.class));
+    }
+
+    // =========================================================================
+    // optional() and summarizedContext()
+    // =========================================================================
+
+    @Test
+    void detect_simpleAgent_defaultOptionalIsFalse() {
+        AgentAnnotationMeta meta = AgentAnnotationMeta.detect(SimpleInterface.class);
+
+        assertNotNull(meta);
+        assertFalse(meta.optional());
+        assertArrayEquals(new String[0], meta.summarizedContext());
+    }
+
+    @Test
+    void detect_optionalSimple_setsOptionalAndSummarizedContext() {
+        AgentAnnotationMeta meta = AgentAnnotationMeta.detect(OptionalSimpleInterface.class);
+
+        assertNotNull(meta);
+        assertTrue(meta.optional());
+        assertArrayEquals(new String[] {"agentA", "agentB"}, meta.rawSummarizedContext());
+        assertArrayEquals(new String[] {"agentA", "agentB"}, meta.summarizedContext());
+    }
+
+    @Test
+    void detect_optionalSequence_setsOptionalAndSummarizedContext() {
+        AgentAnnotationMeta meta = AgentAnnotationMeta.detect(OptionalSequenceInterface.class);
+
+        assertNotNull(meta);
+        assertTrue(meta.optional());
+        assertArrayEquals(new String[] {"writer"}, meta.summarizedContext());
+    }
+
+    @Test
+    void detect_composedAgentDefault_optionalIsFalse() {
+        assertAll(
+                () -> assertFalse(
+                        AgentAnnotationMeta.detect(SequenceInterface.class).optional()),
+                () -> assertFalse(
+                        AgentAnnotationMeta.detect(LoopInterface.class).optional()),
+                () -> assertFalse(
+                        AgentAnnotationMeta.detect(ParallelInterface.class).optional()),
+                () -> assertFalse(AgentAnnotationMeta.detect(ParallelMapperInterface.class)
+                        .optional()),
+                () -> assertFalse(
+                        AgentAnnotationMeta.detect(ConditionalInterface.class).optional()),
+                () -> assertFalse(
+                        AgentAnnotationMeta.detect(SupervisorInterface.class).optional()),
+                () -> assertFalse(
+                        AgentAnnotationMeta.detect(PlannerInterface.class).optional()),
+                () -> assertFalse(AgentAnnotationMeta.detect(A2AInterface.class).optional()),
+                () -> assertFalse(
+                        AgentAnnotationMeta.detect(McpClientInterface.class).optional()),
+                () -> assertFalse(AgentAnnotationMeta.detect(HumanInTheLoopInterface.class)
+                        .optional()));
+    }
+
+    @Test
+    void detect_composedAgentDefault_summarizedContextIsEmpty() {
+        assertAll(
+                () -> assertEquals(
+                        0, AgentAnnotationMeta.detect(SequenceInterface.class).summarizedContext().length),
+                () -> assertEquals(
+                        0, AgentAnnotationMeta.detect(LoopInterface.class).summarizedContext().length),
+                () -> assertEquals(
+                        0, AgentAnnotationMeta.detect(A2AInterface.class).summarizedContext().length));
     }
 }


### PR DESCRIPTION
…nnotations

- Add optional (boolean) and summarizedContext (String[]) to all 11 agent stereotype annotations.
- Extend AgentAnnotationMeta with optional and rawSummarizedContext fields.
- Wire optional through CommonAgentCreator via OptionalNonAiAgentInstance.
- Wire summarizedContext through CommonAgentCreator for Simple agents.
- Update A2AAgentBuilder SPI with backward-compatible build() overload.
- Fix Javadoc placement on RegisterAIService.
- Add AgentAnnotationMetaTest for new attributes.