### PR TITLE
feature: Add typedOutputKey attribute to all agent annotations

### DIFF
--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/AgentAnnotationMeta.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/AgentAnnotationMeta.java
@@ -1,5 +1,7 @@
 package dev.langchain4j.cdi.agent;
 
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.TypedKey;
 import dev.langchain4j.cdi.aiservice.CdiLookupHelper;
 import dev.langchain4j.cdi.spi.RegisterA2AAgent;
 import dev.langchain4j.cdi.spi.RegisterConditionalAgent;
@@ -35,6 +37,7 @@ import java.util.Arrays;
  * @param rawName the agent name before expression resolution
  * @param rawDescription the agent description before expression resolution
  * @param rawOutputKey the output key before expression resolution
+ * @param rawTypedOutputKey the typed output key class, or {@code Agent.NoTypedKey.class} when not set
  * @param async whether the agent executes asynchronously
  * @param optional when {@code true} the agent's execution is silently skipped if any of its arguments is missing in the
  *     agentic scope, instead of failing the entire agentic system
@@ -47,6 +50,7 @@ public record AgentAnnotationMeta(
         String rawName,
         String rawDescription,
         String rawOutputKey,
+        Class<? extends TypedKey<?>> rawTypedOutputKey,
         boolean async,
         boolean optional,
         String[] rawSummarizedContext,
@@ -74,6 +78,7 @@ public record AgentAnnotationMeta(
                     simple.name(),
                     simple.description(),
                     simple.outputKey(),
+                    simple.typedOutputKey(),
                     simple.async(),
                     simple.optional(),
                     simple.summarizedContext(),
@@ -86,6 +91,7 @@ public record AgentAnnotationMeta(
                     seq.name(),
                     seq.description(),
                     seq.outputKey(),
+                    seq.typedOutputKey(),
                     false,
                     seq.optional(),
                     seq.summarizedContext(),
@@ -98,6 +104,7 @@ public record AgentAnnotationMeta(
                     loop.name(),
                     loop.description(),
                     loop.outputKey(),
+                    loop.typedOutputKey(),
                     false,
                     loop.optional(),
                     loop.summarizedContext(),
@@ -110,6 +117,7 @@ public record AgentAnnotationMeta(
                     parallel.name(),
                     parallel.description(),
                     parallel.outputKey(),
+                    parallel.typedOutputKey(),
                     false,
                     parallel.optional(),
                     parallel.summarizedContext(),
@@ -122,6 +130,7 @@ public record AgentAnnotationMeta(
                     mapper.name(),
                     mapper.description(),
                     mapper.outputKey(),
+                    mapper.typedOutputKey(),
                     false,
                     mapper.optional(),
                     mapper.summarizedContext(),
@@ -134,6 +143,7 @@ public record AgentAnnotationMeta(
                     cond.name(),
                     cond.description(),
                     cond.outputKey(),
+                    cond.typedOutputKey(),
                     false,
                     cond.optional(),
                     cond.summarizedContext(),
@@ -146,6 +156,7 @@ public record AgentAnnotationMeta(
                     supervisor.name(),
                     supervisor.description(),
                     supervisor.outputKey(),
+                    supervisor.typedOutputKey(),
                     false,
                     supervisor.optional(),
                     supervisor.summarizedContext(),
@@ -158,6 +169,7 @@ public record AgentAnnotationMeta(
                     planner.name(),
                     planner.description(),
                     planner.outputKey(),
+                    planner.typedOutputKey(),
                     false,
                     planner.optional(),
                     planner.summarizedContext(),
@@ -170,6 +182,7 @@ public record AgentAnnotationMeta(
                     a2a.name(),
                     a2a.description(),
                     a2a.outputKey(),
+                    a2a.typedOutputKey(),
                     a2a.async(),
                     a2a.optional(),
                     a2a.summarizedContext(),
@@ -182,6 +195,7 @@ public record AgentAnnotationMeta(
                     mcp.name(),
                     mcp.description(),
                     mcp.outputKey(),
+                    mcp.typedOutputKey(),
                     mcp.async(),
                     mcp.optional(),
                     mcp.summarizedContext(),
@@ -194,6 +208,7 @@ public record AgentAnnotationMeta(
                     hitl.name(),
                     hitl.description(),
                     hitl.outputKey(),
+                    hitl.typedOutputKey(),
                     hitl.async(),
                     hitl.optional(),
                     hitl.summarizedContext(),
@@ -222,6 +237,11 @@ public record AgentAnnotationMeta(
     /** Expression-resolved output key, equivalent to the annotation's {@code outputKey()} after EL/Config expansion. */
     public String outputKey() {
         return CdiLookupHelper.resolveExpression(rawOutputKey);
+    }
+
+    /** Returns {@code true} when a typed output key class other than {@link Agent.NoTypedKey} is set. */
+    public boolean hasTypedOutputKey() {
+        return rawTypedOutputKey != null && rawTypedOutputKey != Agent.NoTypedKey.class;
     }
 
     /**

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
@@ -6,6 +6,7 @@ import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.AgenticServices;
 import dev.langchain4j.agentic.agent.AgentBuilder;
 import dev.langchain4j.agentic.declarative.PlannerSupplier;
+import dev.langchain4j.agentic.declarative.TypedKey;
 import dev.langchain4j.agentic.internal.AgentExecutor;
 import dev.langchain4j.agentic.internal.AgentInvoker;
 import dev.langchain4j.agentic.internal.AgentUtil;
@@ -156,9 +157,14 @@ public class CommonAgentCreator {
                                 if (hasText(resolvedDescription)) {
                                     builder.description(resolvedDescription);
                                 }
-                                String resolvedOutputKey = CdiLookupHelper.resolveExpression(ann.outputKey());
-                                if (hasText(resolvedOutputKey)) {
-                                    builder.outputKey(resolvedOutputKey);
+                                if (ann.typedOutputKey() != Agent.NoTypedKey.class) {
+                                    warnIfBothOutputKeysSet(ann.outputKey(), ann.typedOutputKey());
+                                    builder.outputKey(ann.typedOutputKey());
+                                } else {
+                                    String resolvedOutputKey = CdiLookupHelper.resolveExpression(ann.outputKey());
+                                    if (hasText(resolvedOutputKey)) {
+                                        builder.outputKey(resolvedOutputKey);
+                                    }
                                 }
                                 builder.async(ann.async());
                                 builder.optional(ann.optional());
@@ -174,7 +180,7 @@ public class CommonAgentCreator {
         X aiService = buildAiServiceForSimple(interfaceClass, ann, chatModel, streamingChatModel, lookup);
         String description = CdiLookupHelper.resolveExpression(ann.description());
         if (!hasText(description)) description = "";
-        String outputKey = CdiLookupHelper.resolveExpression(ann.outputKey());
+        String outputKey = resolveOutputKey(ann.typedOutputKey(), ann.outputKey());
         if (!hasText(outputKey)) outputKey = "";
         AgentListener listener = CdiLookupHelper.resolveSingle(lookup, AgentListener.class, ann.agentListenerName());
         NonAiAgentInstance agentInstance = buildNonAiAgentInstance(
@@ -231,6 +237,7 @@ public class CommonAgentCreator {
                 ann.name(),
                 ann.description(),
                 ann.outputKey(),
+                ann.typedOutputKey(),
                 ann.subAgentNames(),
                 ann.agentListenerName(),
                 lookup);
@@ -250,6 +257,7 @@ public class CommonAgentCreator {
                 ann.name(),
                 ann.description(),
                 ann.outputKey(),
+                ann.typedOutputKey(),
                 ann.subAgentNames(),
                 ann.agentListenerName(),
                 lookup);
@@ -262,6 +270,7 @@ public class CommonAgentCreator {
                 ann.name(),
                 ann.description(),
                 ann.outputKey(),
+                ann.typedOutputKey(),
                 ann.subAgentNames(),
                 ann.agentListenerName(),
                 lookup);
@@ -281,6 +290,7 @@ public class CommonAgentCreator {
                 ann.name(),
                 ann.description(),
                 ann.outputKey(),
+                ann.typedOutputKey(),
                 ann.subAgentNames(),
                 ann.agentListenerName(),
                 lookup);
@@ -293,6 +303,7 @@ public class CommonAgentCreator {
                 ann.name(),
                 ann.description(),
                 ann.outputKey(),
+                ann.typedOutputKey(),
                 ann.subAgentNames(),
                 ann.agentListenerName(),
                 lookup);
@@ -318,14 +329,17 @@ public class CommonAgentCreator {
             builder.supervisorContext(supervisorContext);
         }
         List<Object> subAgents = resolveSubAgents(lookup, ann.subAgentNames());
+        String resolvedOutputKey = resolveOutputKey(ann.typedOutputKey(), ann.outputKey());
         configureCommonFields(
                 builder::subAgents,
                 builder::name,
                 builder::description,
                 builder::outputKey,
+                null,
                 ann.name(),
                 ann.description(),
-                ann.outputKey(),
+                resolvedOutputKey,
+                Agent.NoTypedKey.class,
                 subAgents);
         applyListener(builder::listener, ann.agentListenerName(), lookup);
         return builder.build();
@@ -344,6 +358,7 @@ public class CommonAgentCreator {
                 ann.name(),
                 ann.description(),
                 ann.outputKey(),
+                ann.typedOutputKey(),
                 ann.subAgentNames(),
                 ann.agentListenerName(),
                 lookup);
@@ -355,15 +370,9 @@ public class CommonAgentCreator {
             throw new IllegalArgumentException(
                     "@RegisterA2AAgent on " + interfaceClass.getSimpleName() + ": 'a2aServerUrl' is required.");
         }
+        String outputKey = resolveOutputKey(ann.typedOutputKey(), ann.outputKey());
         X a2aAgent = loadA2ABuilder()
-                .build(
-                        interfaceClass,
-                        url,
-                        CdiLookupHelper.resolveExpression(ann.outputKey()),
-                        ann.async(),
-                        ann.optional(),
-                        ann.agentListenerName(),
-                        lookup);
+                .build(interfaceClass, url, outputKey, ann.async(), ann.optional(), ann.agentListenerName(), lookup);
         return wrapWithAgenticScope(interfaceClass, a2aAgent);
     }
 
@@ -390,7 +399,7 @@ public class CommonAgentCreator {
         if (ann.mcpInputKeys().length > 0) {
             builder.inputKeys(ann.mcpInputKeys());
         }
-        String outputKey = CdiLookupHelper.resolveExpression(ann.outputKey());
+        String outputKey = resolveOutputKey(ann.typedOutputKey(), ann.outputKey());
         if (hasText(outputKey)) {
             builder.outputKey(outputKey);
         }
@@ -419,7 +428,7 @@ public class CommonAgentCreator {
                 throw new RuntimeException(cause);
             }
         });
-        String outputKey = CdiLookupHelper.resolveExpression(ann.outputKey());
+        String outputKey = resolveOutputKey(ann.typedOutputKey(), ann.outputKey());
         if (hasText(outputKey)) {
             builder.outputKey(outputKey);
         }
@@ -558,6 +567,7 @@ public class CommonAgentCreator {
             String name,
             String description,
             String outputKey,
+            Class<? extends TypedKey<?>> typedOutputKey,
             String[] subAgentNames,
             String agentListenerName,
             Instance<Object> lookup) {
@@ -567,9 +577,11 @@ public class CommonAgentCreator {
                 builder::name,
                 builder::description,
                 builder::outputKey,
+                typedOutputKey != Agent.NoTypedKey.class ? builder::outputKey : null,
                 name,
                 description,
                 outputKey,
+                typedOutputKey,
                 subAgents);
         applyListener(builder::listener, agentListenerName, lookup);
         return builder.build();
@@ -580,9 +592,11 @@ public class CommonAgentCreator {
             Consumer<String> nameSetter,
             Consumer<String> descriptionSetter,
             Consumer<String> outputKeySetter,
+            Consumer<Class<? extends TypedKey<?>>> typedOutputKeySetter,
             String rawName,
             String rawDescription,
             String rawOutputKey,
+            Class<? extends TypedKey<?>> typedOutputKey,
             List<Object> subAgents) {
         if (!subAgents.isEmpty()) {
             subAgentsSetter.accept(subAgents);
@@ -595,9 +609,53 @@ public class CommonAgentCreator {
         if (hasText(description)) {
             descriptionSetter.accept(description);
         }
-        String outputKey = CdiLookupHelper.resolveExpression(rawOutputKey);
-        if (hasText(outputKey)) {
-            outputKeySetter.accept(outputKey);
+        if (typedOutputKey != null && typedOutputKey != Agent.NoTypedKey.class) {
+            warnIfBothOutputKeysSet(rawOutputKey, typedOutputKey);
+            if (typedOutputKeySetter != null) {
+                typedOutputKeySetter.accept(typedOutputKey);
+            } else {
+                String resolved = resolveTypedKeyName(typedOutputKey);
+                if (hasText(resolved)) {
+                    outputKeySetter.accept(resolved);
+                }
+            }
+        } else {
+            String outputKey = CdiLookupHelper.resolveExpression(rawOutputKey);
+            if (hasText(outputKey)) {
+                outputKeySetter.accept(outputKey);
+            }
+        }
+    }
+
+    static String resolveOutputKey(Class<? extends TypedKey<?>> typedOutputKey, String rawOutputKey) {
+        if (typedOutputKey != null && typedOutputKey != Agent.NoTypedKey.class) {
+            warnIfBothOutputKeysSet(rawOutputKey, typedOutputKey);
+            return resolveTypedKeyName(typedOutputKey);
+        }
+        return CdiLookupHelper.resolveExpression(rawOutputKey);
+    }
+
+    private static void warnIfBothOutputKeysSet(String rawOutputKey, Class<? extends TypedKey<?>> typedOutputKey) {
+        if (hasText(rawOutputKey)) {
+            LOGGER.log(
+                    Level.WARNING,
+                    "Both outputKey (''{0}'') and typedOutputKey ({1}) are set; typedOutputKey takes precedence",
+                    new Object[] {rawOutputKey, typedOutputKey.getName()});
+        }
+    }
+
+    static String resolveTypedKeyName(Class<? extends TypedKey<?>> typedKeyClass) {
+        try {
+            TypedKey<?> instance = typedKeyClass.getDeclaredConstructor().newInstance();
+            String name = instance.name();
+            return hasText(name) ? name : typedKeyClass.getSimpleName();
+        } catch (Exception e) {
+            LOGGER.log(
+                    Level.WARNING,
+                    e,
+                    () -> "Cannot instantiate TypedKey class " + typedKeyClass.getName()
+                            + " (no accessible no-arg constructor?), falling back to simple class name");
+            return typedKeyClass.getSimpleName();
         }
     }
 
@@ -939,7 +997,7 @@ public class CommonAgentCreator {
         String resolvedName = meta.name();
         String name = hasText(resolvedName) ? resolvedName : entryMethod.getName();
         String desc = meta.description();
-        String outputKey = meta.outputKey();
+        String outputKey = resolveOutputKey(meta.rawTypedOutputKey(), meta.rawOutputKey());
         boolean async = meta.async();
         boolean optional = meta.optional();
         AgentInvoker invoker;

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterA2AAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterA2AAgent.java
@@ -2,6 +2,8 @@ package dev.langchain4j.cdi.spi;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.TypedKey;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Stereotype;
 import java.lang.annotation.Annotation;
@@ -28,6 +30,8 @@ public @interface RegisterA2AAgent {
     String description() default "";
 
     String outputKey() default "";
+
+    Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     boolean async() default false;
 

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterConditionalAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterConditionalAgent.java
@@ -2,6 +2,8 @@ package dev.langchain4j.cdi.spi;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.TypedKey;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Stereotype;
 import java.lang.annotation.Annotation;
@@ -24,6 +26,8 @@ public @interface RegisterConditionalAgent {
     String description() default "";
 
     String outputKey() default "";
+
+    Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterHumanInTheLoopAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterHumanInTheLoopAgent.java
@@ -2,6 +2,8 @@ package dev.langchain4j.cdi.spi;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.TypedKey;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Stereotype;
 import java.lang.annotation.Annotation;
@@ -25,6 +27,8 @@ public @interface RegisterHumanInTheLoopAgent {
     String description() default "";
 
     String outputKey() default "";
+
+    Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     boolean async() default false;
 

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterLoopAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterLoopAgent.java
@@ -2,6 +2,8 @@ package dev.langchain4j.cdi.spi;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.TypedKey;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Stereotype;
 import java.lang.annotation.Annotation;
@@ -22,6 +24,8 @@ public @interface RegisterLoopAgent {
     String description() default "";
 
     String outputKey() default "";
+
+    Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterMcpClientAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterMcpClientAgent.java
@@ -2,6 +2,8 @@ package dev.langchain4j.cdi.spi;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.TypedKey;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Stereotype;
 import java.lang.annotation.Annotation;
@@ -26,6 +28,8 @@ public @interface RegisterMcpClientAgent {
     String description() default "";
 
     String outputKey() default "";
+
+    Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     boolean async() default false;
 

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterParallelAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterParallelAgent.java
@@ -2,6 +2,8 @@ package dev.langchain4j.cdi.spi;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.TypedKey;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Stereotype;
 import java.lang.annotation.Annotation;
@@ -22,6 +24,8 @@ public @interface RegisterParallelAgent {
     String description() default "";
 
     String outputKey() default "";
+
+    Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterParallelMapperAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterParallelMapperAgent.java
@@ -2,6 +2,8 @@ package dev.langchain4j.cdi.spi;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.TypedKey;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Stereotype;
 import java.lang.annotation.Annotation;
@@ -28,6 +30,8 @@ public @interface RegisterParallelMapperAgent {
     String description() default "";
 
     String outputKey() default "";
+
+    Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterPlannerAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterPlannerAgent.java
@@ -2,6 +2,8 @@ package dev.langchain4j.cdi.spi;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.TypedKey;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Stereotype;
 import java.lang.annotation.Annotation;
@@ -28,6 +30,8 @@ public @interface RegisterPlannerAgent {
     String description() default "";
 
     String outputKey() default "";
+
+    Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSequenceAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSequenceAgent.java
@@ -2,6 +2,8 @@ package dev.langchain4j.cdi.spi;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.TypedKey;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Stereotype;
 import java.lang.annotation.Annotation;
@@ -22,6 +24,8 @@ public @interface RegisterSequenceAgent {
     String description() default "";
 
     String outputKey() default "";
+
+    Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSimpleAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSimpleAgent.java
@@ -2,6 +2,8 @@ package dev.langchain4j.cdi.spi;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.TypedKey;
 import dev.langchain4j.guardrail.InputGuardrail;
 import dev.langchain4j.guardrail.OutputGuardrail;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -30,6 +32,8 @@ public @interface RegisterSimpleAgent {
     String description() default "";
 
     String outputKey() default "";
+
+    Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     boolean async() default false;
 

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSupervisorAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSupervisorAgent.java
@@ -2,6 +2,8 @@ package dev.langchain4j.cdi.spi;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.TypedKey;
 import dev.langchain4j.agentic.supervisor.SupervisorContextStrategy;
 import dev.langchain4j.agentic.supervisor.SupervisorResponseStrategy;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -24,6 +26,8 @@ public @interface RegisterSupervisorAgent {
     String description() default "";
 
     String outputKey() default "";
+
+    Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic

--- a/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/AgentAnnotationMetaTest.java
+++ b/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/AgentAnnotationMetaTest.java
@@ -2,6 +2,8 @@ package dev.langchain4j.cdi.agent;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.TypedKey;
 import dev.langchain4j.cdi.spi.RegisterA2AAgent;
 import dev.langchain4j.cdi.spi.RegisterConditionalAgent;
 import dev.langchain4j.cdi.spi.RegisterHumanInTheLoopAgent;
@@ -81,6 +83,19 @@ class AgentAnnotationMetaTest {
             optional = true,
             summarizedContext = {"writer"})
     interface OptionalSequenceInterface {}
+
+    static class ResultKey implements TypedKey<String> {
+        @Override
+        public String name() {
+            return "typedResult";
+        }
+    }
+
+    @RegisterSimpleAgent(name = "typedSimple", description = "typed simple", typedOutputKey = ResultKey.class)
+    interface TypedSimpleInterface {}
+
+    @RegisterSequenceAgent(name = "typedSeq", typedOutputKey = ResultKey.class)
+    interface TypedSequenceInterface {}
 
     interface PlainInterface {}
 
@@ -240,6 +255,63 @@ class AgentAnnotationMetaTest {
 
         assertNotNull(meta);
         assertEquals(meta.rawOutputKey(), meta.outputKey());
+    }
+
+    // =========================================================================
+    // typedOutputKey
+    // =========================================================================
+
+    @Test
+    void detect_typedOutputKey_extractsClass() {
+        AgentAnnotationMeta meta = AgentAnnotationMeta.detect(TypedSimpleInterface.class);
+
+        assertNotNull(meta);
+        assertEquals(ResultKey.class, meta.rawTypedOutputKey());
+        assertTrue(meta.hasTypedOutputKey());
+    }
+
+    @Test
+    void detect_typedOutputKey_composedAgent() {
+        AgentAnnotationMeta meta = AgentAnnotationMeta.detect(TypedSequenceInterface.class);
+
+        assertNotNull(meta);
+        assertEquals(ResultKey.class, meta.rawTypedOutputKey());
+        assertTrue(meta.hasTypedOutputKey());
+    }
+
+    @Test
+    void detect_defaultTypedOutputKey_isNoTypedKey() {
+        AgentAnnotationMeta meta = AgentAnnotationMeta.detect(SimpleInterface.class);
+
+        assertNotNull(meta);
+        assertEquals(Agent.NoTypedKey.class, meta.rawTypedOutputKey());
+        assertFalse(meta.hasTypedOutputKey());
+    }
+
+    @Test
+    void detect_allDefaultAnnotations_haveNoTypedOutputKey() {
+        assertAll(
+                () -> assertFalse(
+                        AgentAnnotationMeta.detect(SimpleInterface.class).hasTypedOutputKey()),
+                () -> assertFalse(
+                        AgentAnnotationMeta.detect(SequenceInterface.class).hasTypedOutputKey()),
+                () -> assertFalse(
+                        AgentAnnotationMeta.detect(LoopInterface.class).hasTypedOutputKey()),
+                () -> assertFalse(
+                        AgentAnnotationMeta.detect(ParallelInterface.class).hasTypedOutputKey()),
+                () -> assertFalse(AgentAnnotationMeta.detect(ParallelMapperInterface.class)
+                        .hasTypedOutputKey()),
+                () -> assertFalse(
+                        AgentAnnotationMeta.detect(ConditionalInterface.class).hasTypedOutputKey()),
+                () -> assertFalse(
+                        AgentAnnotationMeta.detect(SupervisorInterface.class).hasTypedOutputKey()),
+                () -> assertFalse(
+                        AgentAnnotationMeta.detect(PlannerInterface.class).hasTypedOutputKey()),
+                () -> assertFalse(AgentAnnotationMeta.detect(A2AInterface.class).hasTypedOutputKey()),
+                () -> assertFalse(
+                        AgentAnnotationMeta.detect(McpClientInterface.class).hasTypedOutputKey()),
+                () -> assertFalse(AgentAnnotationMeta.detect(HumanInTheLoopInterface.class)
+                        .hasTypedOutputKey()));
     }
 
     // =========================================================================

--- a/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/CommonAgentCreatorTest.java
+++ b/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/CommonAgentCreatorTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.declarative.TypedKey;
 import dev.langchain4j.agentic.internal.AgentExecutor;
 import dev.langchain4j.agentic.internal.AgenticScopeOwner;
 import dev.langchain4j.agentic.internal.InternalAgent;
@@ -45,8 +46,14 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.literal.NamedLiteral;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -476,6 +483,46 @@ class CommonAgentCreatorTest {
     interface McpClientAgentAsync {
 
         String process(@V("input") String input);
+    }
+
+    // --- TypedKey classes for resolveTypedKeyName tests ---
+    static class NamedTypedKey implements TypedKey<String> {
+
+        @Override
+        public String name() {
+            return "myTypedKey";
+        }
+    }
+
+    static class BlankNameTypedKey implements TypedKey<String> {
+
+        @Override
+        public String name() {
+            return "";
+        }
+    }
+
+    static class NullNameTypedKey implements TypedKey<String> {
+
+        @Override
+        public String name() {
+            return null;
+        }
+    }
+
+    static class NoDefaultConstructorTypedKey implements TypedKey<String> {
+
+        @SuppressWarnings("unused")
+        private final String value;
+
+        NoDefaultConstructorTypedKey(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String name() {
+            return "unreachable";
+        }
     }
 
     // --- Missing annotation ---
@@ -1458,6 +1505,89 @@ class CommonAgentCreatorTest {
         ExpressionNamedAgent agent = CommonAgentCreator.create(lookup, ExpressionNamedAgent.class);
         assertNotNull(agent);
         assertTrue(agent.toString().contains("Agent[myAgent]"));
+    }
+
+    // =========================================================================
+    // resolveTypedKeyName
+    // =========================================================================
+    @Test
+    void resolveTypedKeyName_withNamedKey_returnsName() {
+        String result = CommonAgentCreator.resolveTypedKeyName(NamedTypedKey.class);
+        assertEquals("myTypedKey", result);
+    }
+
+    @Test
+    void resolveTypedKeyName_withBlankName_fallsBackToSimpleName() {
+        String result = CommonAgentCreator.resolveTypedKeyName(BlankNameTypedKey.class);
+        assertEquals("BlankNameTypedKey", result);
+    }
+
+    @Test
+    void resolveTypedKeyName_withNullName_fallsBackToSimpleName() {
+        String result = CommonAgentCreator.resolveTypedKeyName(NullNameTypedKey.class);
+        assertEquals("NullNameTypedKey", result);
+    }
+
+    @Test
+    void resolveTypedKeyName_withNoDefaultConstructor_fallsBackToSimpleName() {
+        String result = CommonAgentCreator.resolveTypedKeyName(NoDefaultConstructorTypedKey.class);
+        assertEquals("NoDefaultConstructorTypedKey", result);
+    }
+
+    // =========================================================================
+    // resolveOutputKey
+    // =========================================================================
+    @Test
+    void resolveOutputKey_typedKeyTakesPrecedence() {
+        String result = CommonAgentCreator.resolveOutputKey(NamedTypedKey.class, "");
+        assertEquals("myTypedKey", result);
+    }
+
+    @Test
+    void resolveOutputKey_fallsBackToStringOutputKey() {
+        String result = CommonAgentCreator.resolveOutputKey(Agent.NoTypedKey.class, "stringKey");
+        assertEquals("stringKey", result);
+    }
+
+    @Test
+    void resolveOutputKey_nullTypedKey_fallsBackToStringOutputKey() {
+        String result = CommonAgentCreator.resolveOutputKey(null, "stringKey");
+        assertEquals("stringKey", result);
+    }
+
+    @Test
+    void resolveOutputKey_bothEmpty_returnsEmpty() {
+        String result = CommonAgentCreator.resolveOutputKey(Agent.NoTypedKey.class, "");
+        assertEquals("", result);
+    }
+
+    @Test
+    void resolveOutputKey_bothSet_warnsAndTypedKeyWins() {
+        Logger logger = Logger.getLogger(CommonAgentCreator.class.getName());
+        List<LogRecord> records = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                records.add(record);
+            }
+
+            @Override
+            public void flush() {}
+
+            @Override
+            public void close() {}
+        };
+        logger.addHandler(handler);
+        try {
+            String result = CommonAgentCreator.resolveOutputKey(NamedTypedKey.class, "stringKey");
+            assertEquals("myTypedKey", result);
+            assertEquals(1, records.size());
+            LogRecord record = records.get(0);
+            assertEquals(Level.WARNING, record.getLevel());
+            assertTrue(record.getMessage().contains("typedOutputKey takes precedence"));
+        } finally {
+            logger.removeHandler(handler);
+        }
     }
 
     // =========================================================================


### PR DESCRIPTION
Add a `typedOutputKey` attribute (`Class<? extends TypedKey<?>>`) to all 11 agent stereotype annotations, enabling type-safe output key declarations via TypedKey classes instead of plain strings.

- Extend AgentAnnotationMeta record with rawTypedOutputKey field and hasTypedOutputKey() helper
- Extract resolveOutputKey() and resolveTypedKeyName() in CommonAgentCreator to centralise typed-vs-string output key resolution
- typedOutputKey takes precedence when both are set (with a warning)
- Fall back to class simple name when TypedKey instantiation fails
- Add unit tests for AgentAnnotationMeta and CommonAgentCreator helpers