### PR TITLE
feature: Upgrade langchain4j to 1.16.2 and add agent hook attributes (errorHandler, outputProvider, beforeCall)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,6 +129,58 @@ Resolution is performed by the `ExpressionResolver` SPI (`dev.langchain4j.cdi.sp
 - `RetrievalAugmentor` takes precedence over `ContentRetriever`
 - `ToolProvider` is preferred over the `tools` array
 
+### Registering Agents
+
+Agents are declared using one of 11 per-topology stereotype annotations. Each annotation shares a common set of attributes and may include topology-specific and hook attributes.
+
+**Common attributes (all 11 topologies):**
+
+| Attribute | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `scope` | `Class<? extends Annotation>` | `ApplicationScoped.class` | CDI scope |
+| `name` | `String` | `""` | Agent name |
+| `description` | `String` | `""` | Agent description |
+| `outputKey` | `String` | `""` | Key for storing output in `AgenticScope` |
+| `typedOutputKey` | `Class<? extends TypedKey<?>>` | `Agent.NoTypedKey.class` | Type-safe output key (takes precedence over `outputKey`) |
+| `optional` | `boolean` | `false` | Skip silently when arguments are missing |
+| `summarizedContext` | `String[]` | `{}` | Agent names whose context to summarize and inject |
+| `agentListenerName` | `String` | `""` | CDI bean name of an `AgentListener` |
+
+Note: `async` is available on Simple, A2A, MCP, and HITL topologies only.
+
+**Hook/callback attributes and topology availability:**
+
+| Attribute | Bean type | Topologies |
+|-----------|-----------|------------|
+| `errorHandlerName` | `Function<ErrorContext, ErrorRecoveryResult>` | Sequence, Loop, Parallel, ParallelMapper, Conditional, Planner, Supervisor |
+| `outputProviderName` | `Function<AgenticScope, Object>` | Sequence, Loop, Parallel, ParallelMapper, Conditional, Planner, Supervisor |
+| `beforeCallName` | `Consumer<AgenticScope>` | Sequence, Loop, Parallel, ParallelMapper, Conditional, Planner |
+
+These hooks resolve CDI beans by name. Due to Java type erasure on generics, beans are resolved as `Object` and cast — the bean must implement the correct functional interface. A warning is logged if the resolved bean has the wrong type.
+
+Topologies missing an attribute lack `output()` or `beforeCall()` on their framework builder (`AgentBuilder`, `A2AAgentBuilder`, `McpService`, `HumanInTheLoop`, `SupervisorAgentService`). TODO comments in `CommonAgentCreator` track these gaps for future framework releases.
+
+**Example — sequence agent with error handler and pre-execution hook:**
+
+```java
+@RegisterSequenceAgent(
+    name = "pipeline",
+    subAgentNames = {"step1", "step2", "step3"},
+    errorHandlerName = "pipelineErrorHandler",
+    beforeCallName = "pipelineSetup",
+    outputProviderName = "pipelineOutput"
+)
+public interface PipelineAgent {}
+```
+
+**Agent proxy creation:**
+
+`CommonAgentCreator` uses two proxy creation mechanisms:
+- **`cdiAgentInstanceFactory`**: For `@Agent`-annotated simple agents — passed as the 3rd argument to `AgentConfigurator`, delegates to `AgentBuilder.interfacesToImplement()` to include all framework-required interfaces
+- **`createAgentProxy`**: For non-`@Agent` simple agents and HITL — creates JDK proxies with `[userInterface, InternalAgent, AgenticScopeOwner, AgenticScopeAccess]` plus any extra interfaces
+
+Both mechanisms ensure all agent proxies implement `AgenticScopeAccess` (added in the 1.16.2 upgrade).
+
 ### Configuration-Based Plugin Creation
 
 Components can be created from configuration properties:

--- a/examples/car-booking-mcp/pom.xml
+++ b/examples/car-booking-mcp/pom.xml
@@ -66,7 +66,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${version.compiler.plugin}</version>
-                <configuration />
+                <configuration/>
             </plugin>
 
             <!--Build configuration for the WAR plugin: -->

--- a/examples/liberty-car-booking-mcp/pom.xml
+++ b/examples/liberty-car-booking-mcp/pom.xml
@@ -24,8 +24,8 @@
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <war-plugin.version>3.4.0</war-plugin.version>
         <!-- We need only javac to use the release parameter. OpenLiberty doesn't depend on maven-compiler-plugin.' -->
-        <maven.compiler.source combine.self="override" />
-        <maven.compiler.target combine.self="override" />
+        <maven.compiler.source combine.self="override"/>
+        <maven.compiler.target combine.self="override"/>
 
         <version.io.smallrye.fault-tolerance>6.7.3</version.io.smallrye.fault-tolerance>
         <!--Strictly for OpenLiberty-->

--- a/examples/liberty-car-booking/pom.xml
+++ b/examples/liberty-car-booking/pom.xml
@@ -24,8 +24,8 @@
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <war-plugin.version>3.4.0</war-plugin.version>
         <!-- We need only javac to use the release parameter. OpenLiberty doesn't depend on maven-compiler-plugin.' -->
-        <maven.compiler.source combine.self="override" />
-        <maven.compiler.target combine.self="override" />
+        <maven.compiler.source combine.self="override"/>
+        <maven.compiler.target combine.self="override"/>
 
         <version.io.smallrye.fault-tolerance>6.7.3</version.io.smallrye.fault-tolerance>
         <!--Strictly for OpenLiberty-->

--- a/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/aiservice/Langchain4JAIServiceBuildCompatibleExtension.java
+++ b/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/aiservice/Langchain4JAIServiceBuildCompatibleExtension.java
@@ -2,6 +2,7 @@ package dev.langchain4j.cdi.aiservice;
 
 import dev.langchain4j.agentic.internal.AgenticScopeOwner;
 import dev.langchain4j.agentic.internal.InternalAgent;
+import dev.langchain4j.agentic.scope.AgenticScopeAccess;
 import dev.langchain4j.cdi.agent.AgentAnnotationMeta;
 import dev.langchain4j.cdi.agent.CommonAgentCreator;
 import dev.langchain4j.cdi.spi.RegisterA2AAgent;
@@ -206,7 +207,8 @@ public class Langchain4JAIServiceBuildCompatibleExtension implements BuildCompat
             SyntheticBeanBuilder<Object> agentBuilder = builder.createWith(AIAgentCreator.class)
                     .type(interfaceClass)
                     .type(InternalAgent.class)
-                    .type(AgenticScopeOwner.class);
+                    .type(AgenticScopeOwner.class)
+                    .type(AgenticScopeAccess.class);
             if (meta != null && meta.annotationClass() == RegisterHumanInTheLoopAgent.class) {
                 agentBuilder.type(CommonAgentCreator.HumanInTheLoopHolder.class);
             }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
@@ -5,6 +5,8 @@ import static dev.langchain4j.cdi.aiservice.CdiLookupHelper.hasText;
 import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.AgenticServices;
 import dev.langchain4j.agentic.agent.AgentBuilder;
+import dev.langchain4j.agentic.agent.ErrorContext;
+import dev.langchain4j.agentic.agent.ErrorRecoveryResult;
 import dev.langchain4j.agentic.declarative.PlannerSupplier;
 import dev.langchain4j.agentic.declarative.TypedKey;
 import dev.langchain4j.agentic.internal.AgentExecutor;
@@ -20,6 +22,7 @@ import dev.langchain4j.agentic.planner.AgenticService;
 import dev.langchain4j.agentic.planner.Planner;
 import dev.langchain4j.agentic.planner.PlannerBasedService;
 import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.scope.AgenticScopeAccess;
 import dev.langchain4j.agentic.supervisor.SupervisorAgentService;
 import dev.langchain4j.agentic.workflow.HumanInTheLoop;
 import dev.langchain4j.agentic.workflow.LoopAgentService;
@@ -54,6 +57,7 @@ import jakarta.enterprise.inject.spi.CDI;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -64,6 +68,7 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -86,6 +91,34 @@ public class CommonAgentCreator {
     public static final String AGENT_BEAN_NAME_PREFIX = "registeredAgent-";
 
     private static final String AGENT_TOSTRING_PREFIX = "Agent[";
+
+    static <X> Function<InternalAgent, Object> cdiAgentInstanceFactory(
+            Class<X> interfaceClass, Class<?>... extraInterfaces) {
+        return internalAgent -> {
+            InvocationHandler handler = (InvocationHandler) internalAgent;
+            Set<Class<?>> interfaces = new LinkedHashSet<>();
+            for (Class<?> iface : AgentBuilder.interfacesToImplement(interfaceClass)) {
+                interfaces.add(iface);
+            }
+            for (Class<?> extra : extraInterfaces) {
+                interfaces.add(extra);
+            }
+            return Proxy.newProxyInstance(interfaceClass.getClassLoader(), interfaces.toArray(Class[]::new), handler);
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    static <X> X createAgentProxy(Class<X> interfaceClass, InvocationHandler handler, Class<?>... extraInterfaces) {
+        Set<Class<?>> interfaces = new LinkedHashSet<>();
+        interfaces.add(interfaceClass);
+        interfaces.add(InternalAgent.class);
+        interfaces.add(AgenticScopeOwner.class);
+        interfaces.add(AgenticScopeAccess.class);
+        for (Class<?> extra : extraInterfaces) {
+            interfaces.add(extra);
+        }
+        return (X) Proxy.newProxyInstance(interfaceClass.getClassLoader(), interfaces.toArray(Class[]::new), handler);
+    }
 
     public static <X> X create(Instance<Object> lookup, Class<X> interfaceClass) {
         RegisterSimpleAgent simple = interfaceClass.getAnnotation(RegisterSimpleAgent.class);
@@ -174,7 +207,8 @@ public class CommonAgentCreator {
                             agentClass -> {
                                 Instance<?> instance = lookup.select(agentClass);
                                 return instance.isResolvable() ? instance.get() : null;
-                            }));
+                            },
+                            cdiAgentInstanceFactory(interfaceClass)));
         }
 
         X aiService = buildAiServiceForSimple(interfaceClass, ann, chatModel, streamingChatModel, lookup);
@@ -210,7 +244,7 @@ public class CommonAgentCreator {
             }
             return method.invoke(aiService, args);
         };
-        return AgentUtil.buildAgent(interfaceClass, handler);
+        return createAgentProxy(interfaceClass, handler);
     }
 
     private static <X> X buildAiServiceForSimple(
@@ -240,6 +274,9 @@ public class CommonAgentCreator {
                 ann.typedOutputKey(),
                 ann.subAgentNames(),
                 ann.agentListenerName(),
+                ann.errorHandlerName(),
+                ann.outputProviderName(),
+                ann.beforeCallName(),
                 lookup);
     }
 
@@ -260,6 +297,9 @@ public class CommonAgentCreator {
                 ann.typedOutputKey(),
                 ann.subAgentNames(),
                 ann.agentListenerName(),
+                ann.errorHandlerName(),
+                ann.outputProviderName(),
+                ann.beforeCallName(),
                 lookup);
     }
 
@@ -273,6 +313,9 @@ public class CommonAgentCreator {
                 ann.typedOutputKey(),
                 ann.subAgentNames(),
                 ann.agentListenerName(),
+                ann.errorHandlerName(),
+                ann.outputProviderName(),
+                ann.beforeCallName(),
                 lookup);
     }
 
@@ -293,6 +336,9 @@ public class CommonAgentCreator {
                 ann.typedOutputKey(),
                 ann.subAgentNames(),
                 ann.agentListenerName(),
+                ann.errorHandlerName(),
+                ann.outputProviderName(),
+                ann.beforeCallName(),
                 lookup);
     }
 
@@ -306,6 +352,9 @@ public class CommonAgentCreator {
                 ann.typedOutputKey(),
                 ann.subAgentNames(),
                 ann.agentListenerName(),
+                ann.errorHandlerName(),
+                ann.outputProviderName(),
+                ann.beforeCallName(),
                 lookup);
     }
 
@@ -342,6 +391,8 @@ public class CommonAgentCreator {
                 Agent.NoTypedKey.class,
                 subAgents);
         applyListener(builder::listener, ann.agentListenerName(), lookup);
+        applyErrorHandler(builder::errorHandler, ann.errorHandlerName(), lookup);
+        applyOutputProvider(builder::output, ann.outputProviderName(), lookup);
         return builder.build();
     }
 
@@ -361,6 +412,9 @@ public class CommonAgentCreator {
                 ann.typedOutputKey(),
                 ann.subAgentNames(),
                 ann.agentListenerName(),
+                ann.errorHandlerName(),
+                ann.outputProviderName(),
+                ann.beforeCallName(),
                 lookup);
     }
 
@@ -467,11 +521,7 @@ public class CommonAgentCreator {
             throw new UnsupportedOperationException(
                     "HUMAN_IN_THE_LOOP agents must be invoked through the agentic system");
         };
-        return (X) java.lang.reflect.Proxy.newProxyInstance(
-                interfaceClass.getClassLoader(),
-                new Class<?>[] {interfaceClass, InternalAgent.class, AgenticScopeOwner.class, HumanInTheLoopHolder.class
-                },
-                handler);
+        return createAgentProxy(interfaceClass, handler, HumanInTheLoopHolder.class);
     }
 
     /** Wraps a delegate agent proxy so the result implements {@link AgenticScopeOwner}. */
@@ -570,6 +620,9 @@ public class CommonAgentCreator {
             Class<? extends TypedKey<?>> typedOutputKey,
             String[] subAgentNames,
             String agentListenerName,
+            String errorHandlerName,
+            String outputProviderName,
+            String beforeCallName,
             Instance<Object> lookup) {
         List<Object> subAgents = resolveSubAgents(lookup, subAgentNames);
         configureCommonFields(
@@ -584,6 +637,9 @@ public class CommonAgentCreator {
                 typedOutputKey,
                 subAgents);
         applyListener(builder::listener, agentListenerName, lookup);
+        applyErrorHandler(builder::errorHandler, errorHandlerName, lookup);
+        applyOutputProvider(builder::output, outputProviderName, lookup);
+        applyBeforeCall(builder::beforeCall, beforeCallName, lookup);
         return builder.build();
     }
 
@@ -661,9 +717,77 @@ public class CommonAgentCreator {
 
     private static void applyListener(
             Consumer<AgentListener> setter, String agentListenerName, Instance<Object> lookup) {
+        if (!hasText(agentListenerName)) {
+            return;
+        }
         AgentListener listener = CdiLookupHelper.resolveSingle(lookup, AgentListener.class, agentListenerName);
         if (listener != null) {
             setter.accept(listener);
+        }
+    }
+
+    // TODO: outputProvider is only supported on AgenticService and SupervisorAgentService builders.
+    //  Simple, A2A, MCP, and HITL topologies lack output() on their builders (AgentBuilder, A2AAgentBuilder,
+    //  McpService, HumanInTheLoop). Add outputProviderName to those annotations when the framework exposes it.
+
+    // TODO: beforeCall is only supported on AgenticService builders (sequence, loop, parallel, parallelMapper,
+    //  conditional, planner). Supervisor, Simple, A2A, MCP, and HITL lack beforeCall() on their builders.
+    //  Add beforeCallName to those annotations when the framework exposes it.
+
+    private static void applyErrorHandler(
+            Consumer<Function<ErrorContext, ErrorRecoveryResult>> setter,
+            String errorHandlerName,
+            Instance<Object> lookup) {
+        applyHook(
+                setter,
+                errorHandlerName,
+                Function.class,
+                "errorHandlerName",
+                "Function<ErrorContext, ErrorRecoveryResult>",
+                lookup);
+    }
+
+    private static void applyOutputProvider(
+            Consumer<Function<AgenticScope, Object>> setter, String outputProviderName, Instance<Object> lookup) {
+        applyHook(
+                setter,
+                outputProviderName,
+                Function.class,
+                "outputProviderName",
+                "Function<AgenticScope, Object>",
+                lookup);
+    }
+
+    private static void applyBeforeCall(
+            Consumer<Consumer<AgenticScope>> setter, String beforeCallName, Instance<Object> lookup) {
+        applyHook(setter, beforeCallName, Consumer.class, "beforeCallName", "Consumer<AgenticScope>", lookup);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> void applyHook(
+            Consumer<T> setter,
+            String beanName,
+            Class<? super T> expectedRawType,
+            String hookLabel,
+            String expectedSignature,
+            Instance<Object> lookup) {
+        if (!hasText(beanName)) {
+            return;
+        }
+        Object bean = CdiLookupHelper.resolveSingle(lookup, Object.class, beanName);
+        if (expectedRawType.isInstance(bean)) {
+            T raw = (T) bean;
+            setter.accept(raw);
+        } else if (bean != null) {
+            LOGGER.log(
+                    Level.WARNING,
+                    "{0} ''{1}'' resolved to a bean of type {2} which is not a {3}; ignoring",
+                    new Object[] {
+                        hookLabel,
+                        CdiLookupHelper.resolveExpression(beanName),
+                        bean.getClass().getName(),
+                        expectedSignature
+                    });
         }
     }
 

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterA2AAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterA2AAgent.java
@@ -46,6 +46,8 @@ public @interface RegisterA2AAgent {
 
     String agentListenerName() default "";
 
+    // TODO: add errorHandlerName when A2AAgentBuilder exposes errorHandler()
+
     /** URL of the A2A server. Required. */
     String a2aServerUrl();
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterConditionalAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterConditionalAgent.java
@@ -40,5 +40,11 @@ public @interface RegisterConditionalAgent {
 
     String agentListenerName() default "";
 
+    String errorHandlerName() default "";
+
+    String outputProviderName() default "";
+
+    String beforeCallName() default "";
+
     String[] subAgentNames() default {};
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterHumanInTheLoopAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterHumanInTheLoopAgent.java
@@ -43,6 +43,8 @@ public @interface RegisterHumanInTheLoopAgent {
 
     String agentListenerName() default "";
 
+    // TODO: add errorHandlerName when HumanInTheLoop exposes errorHandler()
+
     /**
      * Name of a static method on the annotated interface that provides the human response. The method must accept a
      * single {@code AgenticScope} parameter and return {@code String}. When empty, the framework selects the only

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterLoopAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterLoopAgent.java
@@ -38,6 +38,12 @@ public @interface RegisterLoopAgent {
 
     String agentListenerName() default "";
 
+    String errorHandlerName() default "";
+
+    String outputProviderName() default "";
+
+    String beforeCallName() default "";
+
     String[] subAgentNames() default {};
 
     int maxIterations() default 10;

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterMcpClientAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterMcpClientAgent.java
@@ -44,6 +44,8 @@ public @interface RegisterMcpClientAgent {
 
     String agentListenerName() default "";
 
+    // TODO: add errorHandlerName when McpService exposes errorHandler()
+
     /** CDI bean name of the MCP client object. Required. */
     String mcpClientName();
 

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterParallelAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterParallelAgent.java
@@ -38,5 +38,11 @@ public @interface RegisterParallelAgent {
 
     String agentListenerName() default "";
 
+    String errorHandlerName() default "";
+
+    String outputProviderName() default "";
+
+    String beforeCallName() default "";
+
     String[] subAgentNames() default {};
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterParallelMapperAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterParallelMapperAgent.java
@@ -44,6 +44,12 @@ public @interface RegisterParallelMapperAgent {
 
     String agentListenerName() default "";
 
+    String errorHandlerName() default "";
+
+    String outputProviderName() default "";
+
+    String beforeCallName() default "";
+
     String[] subAgentNames() default {};
 
     /** Key in {@link dev.langchain4j.agentic.scope.AgenticScope} that holds the list of items to map over. Required. */

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterPlannerAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterPlannerAgent.java
@@ -44,6 +44,12 @@ public @interface RegisterPlannerAgent {
 
     String agentListenerName() default "";
 
+    String errorHandlerName() default "";
+
+    String outputProviderName() default "";
+
+    String beforeCallName() default "";
+
     String[] subAgentNames() default {};
 
     String plannerName() default "";

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSequenceAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSequenceAgent.java
@@ -38,5 +38,11 @@ public @interface RegisterSequenceAgent {
 
     String agentListenerName() default "";
 
+    String errorHandlerName() default "";
+
+    String outputProviderName() default "";
+
+    String beforeCallName() default "";
+
     String[] subAgentNames() default {};
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSimpleAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSimpleAgent.java
@@ -48,6 +48,8 @@ public @interface RegisterSimpleAgent {
 
     String agentListenerName() default "";
 
+    // TODO: add errorHandlerName when AgentBuilder exposes errorHandler()
+
     String chatModelName() default "#default";
 
     String streamingChatModelName() default "";

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSupervisorAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSupervisorAgent.java
@@ -40,6 +40,12 @@ public @interface RegisterSupervisorAgent {
 
     String agentListenerName() default "";
 
+    String errorHandlerName() default "";
+
+    String outputProviderName() default "";
+
+    // TODO: add beforeCallName when SupervisorAgentService exposes beforeCall()
+
     String[] subAgentNames() default {};
 
     String chatModelName() default "#default";

--- a/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/CommonAgentCreatorTest.java
+++ b/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/CommonAgentCreatorTest.java
@@ -5,6 +5,9 @@ import static org.mockito.Mockito.*;
 
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.agentic.agent.AgentBuilder;
+import dev.langchain4j.agentic.agent.ErrorContext;
+import dev.langchain4j.agentic.agent.ErrorRecoveryResult;
 import dev.langchain4j.agentic.declarative.TypedKey;
 import dev.langchain4j.agentic.internal.AgentExecutor;
 import dev.langchain4j.agentic.internal.AgenticScopeOwner;
@@ -14,6 +17,7 @@ import dev.langchain4j.agentic.internal.McpService;
 import dev.langchain4j.agentic.observability.AgentListener;
 import dev.langchain4j.agentic.planner.Planner;
 import dev.langchain4j.agentic.scope.AgenticScope;
+import dev.langchain4j.agentic.scope.AgenticScopeAccess;
 import dev.langchain4j.agentic.workflow.HumanInTheLoop;
 import dev.langchain4j.cdi.agent.CommonAgentCreator.HumanInTheLoopHolder;
 import dev.langchain4j.cdi.aiservice.CdiLookupHelper;
@@ -44,11 +48,16 @@ import dev.langchain4j.service.V;
 import dev.langchain4j.service.tool.ToolProvider;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.literal.NamedLiteral;
+import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.function.BiPredicate;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.logging.Handler;
 import java.util.logging.Level;
@@ -351,6 +360,51 @@ class CommonAgentCreatorTest {
             subAgentNames = {"workerAgent"},
             supervisorContext = "Always respond in formal English")
     interface SupervisorOrchestratorWithContext {
+
+        String process(@V("input") String input);
+    }
+
+    // --- Test interfaces for hook attribute wiring ---
+    @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+    @RegisterSequenceAgent(
+            subAgentNames = {"stepA", "stepB"},
+            errorHandlerName = "myErrorHandler",
+            outputProviderName = "myOutputProvider",
+            beforeCallName = "myBeforeCall")
+    interface SequenceWithAllHooks {
+
+        String process(@V("input") String input);
+    }
+
+    @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+    @RegisterSequenceAgent(
+            subAgentNames = {"stepA", "stepB"},
+            errorHandlerName = "wrongTypeBean",
+            outputProviderName = "wrongTypeBean",
+            beforeCallName = "wrongTypeBean")
+    interface SequenceWithWrongTypeHooks {
+
+        String process(@V("input") String input);
+    }
+
+    @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+    @RegisterSequenceAgent(
+            subAgentNames = {"stepA", "stepB"},
+            errorHandlerName = "${myErrorHandler}",
+            outputProviderName = "${myOutputProvider}",
+            beforeCallName = "${myBeforeCall}")
+    interface SequenceWithExpressionHooks {
+
+        String process(@V("input") String input);
+    }
+
+    @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+    @RegisterSupervisorAgent(
+            chatModelName = "#default",
+            subAgentNames = {"workerAgent"},
+            errorHandlerName = "myErrorHandler",
+            outputProviderName = "myOutputProvider")
+    interface SupervisorWithHooks {
 
         String process(@V("input") String input);
     }
@@ -1588,6 +1642,223 @@ class CommonAgentCreatorTest {
         } finally {
             logger.removeHandler(handler);
         }
+    }
+
+    // =========================================================================
+    // Hook attribute wiring (errorHandler, outputProvider, beforeCall)
+    // =========================================================================
+
+    @SuppressWarnings("unchecked")
+    private static Instance<Object> prepareLookupsWithHookBeans(String... agentNames) {
+        Instance<Object> lookup = prepareLookupsWithSubAgents(agentNames);
+
+        Function<ErrorContext, ErrorRecoveryResult> errorHandler = ctx -> ErrorRecoveryResult.throwException();
+        Instance<Object> ehInstance = mock(Instance.class);
+        when(lookup.select(Object.class, NamedLiteral.of("myErrorHandler"))).thenReturn(ehInstance);
+        when(ehInstance.isResolvable()).thenReturn(true);
+        when(ehInstance.get()).thenReturn(errorHandler);
+
+        Function<AgenticScope, Object> outputProvider = scope -> "output";
+        Instance<Object> opInstance = mock(Instance.class);
+        when(lookup.select(Object.class, NamedLiteral.of("myOutputProvider"))).thenReturn(opInstance);
+        when(opInstance.isResolvable()).thenReturn(true);
+        when(opInstance.get()).thenReturn(outputProvider);
+
+        Consumer<AgenticScope> beforeCall = scope -> {};
+        Instance<Object> bcInstance = mock(Instance.class);
+        when(lookup.select(Object.class, NamedLiteral.of("myBeforeCall"))).thenReturn(bcInstance);
+        when(bcInstance.isResolvable()).thenReturn(true);
+        when(bcInstance.get()).thenReturn(beforeCall);
+
+        return lookup;
+    }
+
+    @Test
+    void create_sequenceTopology_wiresErrorHandler() {
+        Instance<Object> lookup = prepareLookupsWithHookBeans("stepA", "stepB");
+        SequenceWithAllHooks agent = CommonAgentCreator.create(lookup, SequenceWithAllHooks.class);
+
+        assertNotNull(agent);
+        verify(lookup).select(Object.class, NamedLiteral.of("myErrorHandler"));
+    }
+
+    @Test
+    void create_sequenceTopology_wiresOutputProvider() {
+        Instance<Object> lookup = prepareLookupsWithHookBeans("stepA", "stepB");
+        SequenceWithAllHooks agent = CommonAgentCreator.create(lookup, SequenceWithAllHooks.class);
+
+        assertNotNull(agent);
+        verify(lookup).select(Object.class, NamedLiteral.of("myOutputProvider"));
+    }
+
+    @Test
+    void create_sequenceTopology_wiresBeforeCall() {
+        Instance<Object> lookup = prepareLookupsWithHookBeans("stepA", "stepB");
+        SequenceWithAllHooks agent = CommonAgentCreator.create(lookup, SequenceWithAllHooks.class);
+
+        assertNotNull(agent);
+        verify(lookup).select(Object.class, NamedLiteral.of("myBeforeCall"));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void create_sequenceTopology_logsWarningWhenHookBeansHaveWrongType() {
+        Instance<Object> lookup = prepareLookupsWithSubAgents("stepA", "stepB");
+        String wrongBean = "not-a-function";
+        Instance<Object> wrongInstance = mock(Instance.class);
+        when(lookup.select(Object.class, NamedLiteral.of("wrongTypeBean"))).thenReturn(wrongInstance);
+        when(wrongInstance.isResolvable()).thenReturn(true);
+        when(wrongInstance.get()).thenReturn(wrongBean);
+
+        Logger logger = Logger.getLogger(CommonAgentCreator.class.getName());
+        List<LogRecord> records = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                records.add(record);
+            }
+
+            @Override
+            public void flush() {}
+
+            @Override
+            public void close() {}
+        };
+        logger.addHandler(handler);
+        try {
+            SequenceWithWrongTypeHooks agent = CommonAgentCreator.create(lookup, SequenceWithWrongTypeHooks.class);
+
+            assertNotNull(agent);
+            assertEquals(3, records.size());
+            assertTrue(records.stream().allMatch(r -> r.getLevel() == Level.WARNING));
+            assertTrue(records.stream()
+                    .allMatch(r -> r.getParameters() != null && "wrongTypeBean".equals(r.getParameters()[1])));
+            assertTrue(records.stream().anyMatch(r -> "errorHandlerName".equals(r.getParameters()[0])));
+            assertTrue(records.stream().anyMatch(r -> "outputProviderName".equals(r.getParameters()[0])));
+            assertTrue(records.stream().anyMatch(r -> "beforeCallName".equals(r.getParameters()[0])));
+        } finally {
+            logger.removeHandler(handler);
+        }
+    }
+
+    @Test
+    void create_sequenceTopology_resolvesExpressionInHookNames() {
+        Instance<Object> lookup = prepareLookupsWithHookBeans("stepA", "stepB");
+        SequenceWithExpressionHooks agent = CommonAgentCreator.create(lookup, SequenceWithExpressionHooks.class);
+
+        assertNotNull(agent);
+        verify(lookup).select(Object.class, NamedLiteral.of("myErrorHandler"));
+        verify(lookup).select(Object.class, NamedLiteral.of("myOutputProvider"));
+        verify(lookup).select(Object.class, NamedLiteral.of("myBeforeCall"));
+    }
+
+    @Test
+    void create_sequenceTopology_noOpWhenHookNamesEmpty() {
+        Instance<Object> lookup = prepareLookupsWithSubAgents("stepA", "stepB");
+        SequenceOrchestrator agent = CommonAgentCreator.create(lookup, SequenceOrchestrator.class);
+
+        assertNotNull(agent);
+        verify(lookup, never()).select(Object.class, NamedLiteral.of("myErrorHandler"));
+        verify(lookup, never()).select(Object.class, NamedLiteral.of("myOutputProvider"));
+        verify(lookup, never()).select(Object.class, NamedLiteral.of("myBeforeCall"));
+    }
+
+    @Test
+    void create_supervisorTopology_wiresErrorHandlerAndOutputProvider() {
+        Instance<Object> lookup = prepareLookupsWithHookBeans("workerAgent");
+        SupervisorWithHooks agent = CommonAgentCreator.create(lookup, SupervisorWithHooks.class);
+
+        assertNotNull(agent);
+        verify(lookup).select(Object.class, NamedLiteral.of("myErrorHandler"));
+        verify(lookup).select(Object.class, NamedLiteral.of("myOutputProvider"));
+        verify(lookup, never()).select(Object.class, NamedLiteral.of("myBeforeCall"));
+    }
+
+    // =========================================================================
+    // Proxy factory methods (cdiAgentInstanceFactory / createAgentProxy)
+    // =========================================================================
+
+    private static final InvocationHandler NO_OP_HANDLER = (proxy, method, args) -> {
+        if ("toString".equals(method.getName())) return "test-proxy";
+        return null;
+    };
+
+    private static InternalAgent createStubInternalAgent() {
+        return (InternalAgent) java.lang.reflect.Proxy.newProxyInstance(
+                CommonAgentCreatorTest.class.getClassLoader(),
+                new Class<?>[] {InternalAgent.class, InvocationHandler.class},
+                NO_OP_HANDLER);
+    }
+
+    @Test
+    void cdiAgentInstanceFactory_includesAllFrameworkInterfaces() {
+        Function<InternalAgent, Object> factory = CommonAgentCreator.cdiAgentInstanceFactory(SimpleAgent.class);
+
+        Object proxy = factory.apply(createStubInternalAgent());
+
+        Set<Class<?>> frameworkInterfaces = Set.of(AgentBuilder.interfacesToImplement(SimpleAgent.class));
+        for (Class<?> iface : frameworkInterfaces) {
+            assertTrue(iface.isInstance(proxy), "Proxy should implement " + iface.getName());
+        }
+    }
+
+    @Test
+    void cdiAgentInstanceFactory_includesExtraInterfaces() {
+        Function<InternalAgent, Object> factory =
+                CommonAgentCreator.cdiAgentInstanceFactory(SimpleAgent.class, HumanInTheLoopHolder.class);
+
+        Object proxy = factory.apply(createStubInternalAgent());
+
+        assertTrue(proxy instanceof HumanInTheLoopHolder, "Proxy should implement extra interface");
+        Set<Class<?>> frameworkInterfaces = Set.of(AgentBuilder.interfacesToImplement(SimpleAgent.class));
+        for (Class<?> iface : frameworkInterfaces) {
+            assertTrue(iface.isInstance(proxy), "Proxy should still implement " + iface.getName());
+        }
+    }
+
+    @Test
+    void cdiAgentInstanceFactory_deduplicatesInterfaces() {
+        Function<InternalAgent, Object> factory =
+                CommonAgentCreator.cdiAgentInstanceFactory(SimpleAgent.class, InternalAgent.class);
+
+        Object proxy = factory.apply(createStubInternalAgent());
+        assertNotNull(proxy);
+        long count = Arrays.stream(proxy.getClass().getInterfaces())
+                .filter(i -> i == InternalAgent.class)
+                .count();
+        assertEquals(1, count, "InternalAgent should appear only once even when passed as extra");
+    }
+
+    @Test
+    void createAgentProxy_includesFixedInterfaceSet() {
+        SimpleAgent proxy = CommonAgentCreator.createAgentProxy(SimpleAgent.class, NO_OP_HANDLER);
+
+        assertTrue(proxy instanceof SimpleAgent);
+        assertTrue(proxy instanceof InternalAgent);
+        assertTrue(proxy instanceof AgenticScopeOwner);
+        assertTrue(proxy instanceof AgenticScopeAccess);
+    }
+
+    @Test
+    void createAgentProxy_includesExtraInterfaces() {
+        SimpleAgent proxy =
+                CommonAgentCreator.createAgentProxy(SimpleAgent.class, NO_OP_HANDLER, HumanInTheLoopHolder.class);
+
+        assertTrue(proxy instanceof HumanInTheLoopHolder);
+        assertTrue(proxy instanceof InternalAgent);
+        assertTrue(proxy instanceof AgenticScopeOwner);
+        assertTrue(proxy instanceof AgenticScopeAccess);
+    }
+
+    @Test
+    void createAgentProxy_deduplicatesInterfaces() {
+        SimpleAgent proxy = CommonAgentCreator.createAgentProxy(SimpleAgent.class, NO_OP_HANDLER, InternalAgent.class);
+
+        assertNotNull(proxy);
+        long count = Arrays.stream(proxy.getClass().getInterfaces())
+                .filter(i -> i == InternalAgent.class)
+                .count();
+        assertEquals(1, count, "InternalAgent should appear only once even when passed as extra");
     }
 
     // =========================================================================

--- a/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/LangChain4JAIAgentBean.java
+++ b/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/LangChain4JAIAgentBean.java
@@ -2,6 +2,7 @@ package dev.langchain4j.cdi.core.portableextension;
 
 import dev.langchain4j.agentic.internal.AgenticScopeOwner;
 import dev.langchain4j.agentic.internal.InternalAgent;
+import dev.langchain4j.agentic.scope.AgenticScopeAccess;
 import dev.langchain4j.cdi.agent.AgentAnnotationMeta;
 import dev.langchain4j.cdi.agent.CommonAgentCreator;
 import dev.langchain4j.cdi.aiservice.CdiLookupHelper;
@@ -74,6 +75,7 @@ public class LangChain4JAIAgentBean<T> implements Bean<T>, PassivationCapable {
         types.add(agentInterfaceClass);
         types.add(InternalAgent.class);
         types.add(AgenticScopeOwner.class);
+        types.add(AgenticScopeAccess.class);
         if (stereotypeAnnotationClass == RegisterHumanInTheLoopAgent.class) {
             types.add(CommonAgentCreator.HumanInTheLoopHolder.class);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>2026-06-05T12:39:44Z</project.build.outputTimestamp>
 
-        <dev.langchain4j.version>1.15.1</dev.langchain4j.version>
-        <dev.langchain4j.agentic.version>1.15.1-beta25</dev.langchain4j.agentic.version>
-        <dev.langchain4j.community.version>1.15.1-beta25</dev.langchain4j.community.version>
+        <dev.langchain4j.version>1.16.2</dev.langchain4j.version>
+        <dev.langchain4j.agentic.version>1.16.2-beta26</dev.langchain4j.agentic.version>
+        <dev.langchain4j.community.version>1.16.0-beta26</dev.langchain4j.community.version>
         <jakartaee-api.version>10.0.0</jakartaee-api.version>
         <jakarta.enterprise.cdi-api.version>4.0.1</jakarta.enterprise.cdi-api.version>
         <org.mcp-java.version>1.0.0-Beta1</org.mcp-java.version>


### PR DESCRIPTION
- Bump langchain4j 1.16.0 -> 1.16.2 and agentic 1.16.0-beta26 -> 1.16.2-beta26.
- Leverage the new AgentConfigurator.agentInstanceFactory to provide a CDI-aware proxy factory and ensure all agent proxies implement AgenticScopeAccess.
- Add errorHandlerName, outputProviderName, and beforeCallName attributes to agent annotations where the framework builder supports them.