### PR TITLE
Removed smallrye fault tolerance from Liberty example

### DIFF
--- a/examples/car-booking-mcp/pom.xml
+++ b/examples/car-booking-mcp/pom.xml
@@ -66,7 +66,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${version.compiler.plugin}</version>
-                <configuration />
+                <configuration/>
             </plugin>
 
             <!--Build configuration for the WAR plugin: -->

--- a/examples/liberty-car-booking-mcp/pom.xml
+++ b/examples/liberty-car-booking-mcp/pom.xml
@@ -24,8 +24,8 @@
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <war-plugin.version>3.4.0</war-plugin.version>
         <!-- We need only javac to use the release parameter. OpenLiberty doesn't depend on maven-compiler-plugin.' -->
-        <maven.compiler.source combine.self="override" />
-        <maven.compiler.target combine.self="override" />
+        <maven.compiler.source combine.self="override"/>
+        <maven.compiler.target combine.self="override"/>
 
         <version.io.smallrye.fault-tolerance>6.7.3</version.io.smallrye.fault-tolerance>
         <!--Strictly for OpenLiberty-->
@@ -55,12 +55,6 @@
                 <version>2.10.0</version>
                 <scope>provided</scope>
             </dependency>
-
-            <dependency>
-                <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-fault-tolerance</artifactId>
-                <version>${version.io.smallrye.fault-tolerance}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -87,11 +81,6 @@
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-instrumentation-annotations</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-fault-tolerance</artifactId>
         </dependency>
 
         <dependency>

--- a/examples/liberty-car-booking/pom.xml
+++ b/examples/liberty-car-booking/pom.xml
@@ -24,8 +24,8 @@
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <war-plugin.version>3.4.0</war-plugin.version>
         <!-- We need only javac to use the release parameter. OpenLiberty doesn't depend on maven-compiler-plugin.' -->
-        <maven.compiler.source combine.self="override" />
-        <maven.compiler.target combine.self="override" />
+        <maven.compiler.source combine.self="override"/>
+        <maven.compiler.target combine.self="override"/>
 
         <version.io.smallrye.fault-tolerance>6.7.3</version.io.smallrye.fault-tolerance>
         <!--Strictly for OpenLiberty-->
@@ -62,12 +62,6 @@
                 <version>2.10.0</version>
                 <scope>provided</scope>
             </dependency>
-
-            <dependency>
-                <groupId>io.smallrye</groupId>
-                <artifactId>smallrye-fault-tolerance</artifactId>
-                <version>${version.io.smallrye.fault-tolerance}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -94,11 +88,6 @@
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-instrumentation-annotations</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-fault-tolerance</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
As per bug #230, I removed smallrye fault tolerance from Liberty example.