### PR TITLE
test(fault-tolerance): add interceptor binding tests for all FT annot…

### DIFF
--- a/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/pom.xml
+++ b/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/pom.xml
@@ -17,6 +17,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
             <artifactId>microprofile-fault-tolerance-api</artifactId>
             <scope>provided</scope>
@@ -24,6 +29,37 @@
         <dependency>
             <groupId>dev.langchain4j.cdi</groupId>
             <artifactId>langchain4j-cdi-portable-ext</artifactId>
+        </dependency>
+        <!-- TEST -->
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-agentic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j.cdi.mp</groupId>
+            <artifactId>langchain4j-cdi-config</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-core-impl</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/AsynchronousAgentService.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/AsynchronousAgentService.java
@@ -1,0 +1,18 @@
+package dev.langchain4j.cdi.faulttolerance.spi;
+
+import dev.langchain4j.cdi.spi.RegisterSimpleAgent;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import jakarta.enterprise.context.ApplicationScoped;
+import java.util.concurrent.CompletionStage;
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+
+// @SuppressWarnings: CDI proxy is created by the portable extension, not by the container directly
+@SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+@RegisterSimpleAgent(chatModelName = "#default", scope = ApplicationScoped.class)
+public interface AsynchronousAgentService {
+
+    @Asynchronous
+    @UserMessage("{question}")
+    CompletionStage<String> chat(@V("question") String question);
+}

--- a/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/BulkheadAgentService.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/BulkheadAgentService.java
@@ -1,0 +1,17 @@
+package dev.langchain4j.cdi.faulttolerance.spi;
+
+import dev.langchain4j.cdi.spi.RegisterSimpleAgent;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+
+// @SuppressWarnings: CDI proxy is created by the portable extension, not by the container directly
+@SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+@RegisterSimpleAgent(chatModelName = "#default", scope = ApplicationScoped.class)
+public interface BulkheadAgentService {
+
+    @Bulkhead(5)
+    @UserMessage("{question}")
+    String chat(@V("question") String question);
+}

--- a/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/DummyChatModel.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/DummyChatModel.java
@@ -1,0 +1,13 @@
+package dev.langchain4j.cdi.faulttolerance.spi;
+
+import dev.langchain4j.model.chat.ChatModel;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class DummyChatModel implements ChatModel {
+
+    @Override
+    public String chat(String userMessage) {
+        return "dummy";
+    }
+}

--- a/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/FallbackAgentService.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/FallbackAgentService.java
@@ -1,0 +1,21 @@
+package dev.langchain4j.cdi.faulttolerance.spi;
+
+import dev.langchain4j.cdi.spi.RegisterSimpleAgent;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+
+// @SuppressWarnings: CDI proxy is created by the portable extension, not by the container directly
+@SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+@RegisterSimpleAgent(chatModelName = "#default", scope = ApplicationScoped.class)
+public interface FallbackAgentService {
+
+    @Fallback(fallbackMethod = "fallback")
+    @UserMessage("{question}")
+    String chat(@V("question") String question);
+
+    default String fallback(String question) {
+        return "fallback";
+    }
+}

--- a/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/FaultToleranceAgentExtensionTest.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/FaultToleranceAgentExtensionTest.java
@@ -1,0 +1,97 @@
+package dev.langchain4j.cdi.faulttolerance.spi;
+
+import dev.langchain4j.cdi.core.portableextension.InterceptorBeanAttributes;
+import dev.langchain4j.cdi.core.portableextension.LangChain4JAIServicePortableExtension;
+import dev.langchain4j.cdi.core.portableextension.LangChain4JPluginsPortableExtension;
+import io.smallrye.config.inject.ConfigExtension;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import java.lang.annotation.Annotation;
+import java.util.Set;
+import org.jboss.weld.junit5.WeldInitiator;
+import org.jboss.weld.junit5.WeldJunit5Extension;
+import org.jboss.weld.junit5.WeldSetup;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(WeldJunit5Extension.class)
+class FaultToleranceAgentExtensionTest {
+
+    @Inject
+    BeanManager beanManager;
+
+    @WeldSetup
+    public WeldInitiator weld = WeldInitiator.from(
+                    LangChain4JAIServicePortableExtension.class,
+                    LangChain4JPluginsPortableExtension.class,
+                    Langchain4JFaultToleranceExtension.class,
+                    RetryAgentService.class,
+                    RetrySequenceAgentService.class,
+                    TimeoutAgentService.class,
+                    BulkheadAgentService.class,
+                    FallbackAgentService.class,
+                    AsynchronousAgentService.class,
+                    PlainAgentService.class,
+                    DummyChatModel.class,
+                    ConfigExtension.class)
+            .build();
+
+    private void assertFaultToleranceBinding(Class<?> serviceClass, boolean expected, String message) {
+        Bean<?> bean = beanManager.getBeans(serviceClass).iterator().next();
+        Assertions.assertInstanceOf(InterceptorBeanAttributes.class, bean);
+
+        Set<Annotation> bindings = ((InterceptorBeanAttributes<?>) bean).getInterceptorBindings();
+        boolean has = bindings.stream().anyMatch(a -> a.annotationType() == ApplyFaultTolerance.class);
+        Assertions.assertEquals(expected, has, message);
+    }
+
+    @Test
+    void agentWithRetryGetsInterceptorBinding() {
+        assertFaultToleranceBinding(
+                RetryAgentService.class, true, "@RegisterSimpleAgent with @Retry must get @ApplyFaultTolerance");
+    }
+
+    @Test
+    void sequenceAgentWithCircuitBreakerGetsInterceptorBinding() {
+        assertFaultToleranceBinding(
+                RetrySequenceAgentService.class,
+                true,
+                "@RegisterSequenceAgent with @CircuitBreaker must get @ApplyFaultTolerance");
+    }
+
+    @Test
+    void agentWithTimeoutGetsInterceptorBinding() {
+        assertFaultToleranceBinding(
+                TimeoutAgentService.class, true, "@RegisterSimpleAgent with @Timeout must get @ApplyFaultTolerance");
+    }
+
+    @Test
+    void agentWithBulkheadGetsInterceptorBinding() {
+        assertFaultToleranceBinding(
+                BulkheadAgentService.class, true, "@RegisterSimpleAgent with @Bulkhead must get @ApplyFaultTolerance");
+    }
+
+    @Test
+    void agentWithFallbackGetsInterceptorBinding() {
+        assertFaultToleranceBinding(
+                FallbackAgentService.class, true, "@RegisterSimpleAgent with @Fallback must get @ApplyFaultTolerance");
+    }
+
+    @Test
+    void agentWithAsynchronousGetsInterceptorBinding() {
+        assertFaultToleranceBinding(
+                AsynchronousAgentService.class,
+                true,
+                "@RegisterSimpleAgent with @Asynchronous must get @ApplyFaultTolerance");
+    }
+
+    @Test
+    void agentWithoutFaultToleranceAnnotationsGetsNoBinding() {
+        assertFaultToleranceBinding(
+                PlainAgentService.class,
+                false,
+                "@RegisterSimpleAgent without fault tolerance annotations must not get @ApplyFaultTolerance");
+    }
+}

--- a/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/PlainAgentService.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/PlainAgentService.java
@@ -1,0 +1,15 @@
+package dev.langchain4j.cdi.faulttolerance.spi;
+
+import dev.langchain4j.cdi.spi.RegisterSimpleAgent;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import jakarta.enterprise.context.ApplicationScoped;
+
+// @SuppressWarnings: CDI proxy is created by the portable extension, not by the container directly
+@SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+@RegisterSimpleAgent(chatModelName = "#default", scope = ApplicationScoped.class)
+public interface PlainAgentService {
+
+    @UserMessage("{question}")
+    String chat(@V("question") String question);
+}

--- a/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/RetryAgentService.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/RetryAgentService.java
@@ -1,0 +1,17 @@
+package dev.langchain4j.cdi.faulttolerance.spi;
+
+import dev.langchain4j.cdi.spi.RegisterSimpleAgent;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+// @SuppressWarnings: CDI proxy is created by the portable extension, not by the container directly
+@SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+@RegisterSimpleAgent(chatModelName = "#default", scope = ApplicationScoped.class)
+public interface RetryAgentService {
+
+    @Retry(maxRetries = 3)
+    @UserMessage("{question}")
+    String chat(@V("question") String question);
+}

--- a/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/RetrySequenceAgentService.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/RetrySequenceAgentService.java
@@ -1,0 +1,14 @@
+package dev.langchain4j.cdi.faulttolerance.spi;
+
+import dev.langchain4j.cdi.spi.RegisterSequenceAgent;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+// @SuppressWarnings: CDI proxy is created by the portable extension, not by the container directly
+@SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+@RegisterSequenceAgent(scope = ApplicationScoped.class)
+public interface RetrySequenceAgentService {
+
+    @CircuitBreaker(requestVolumeThreshold = 4)
+    String run(String input);
+}

--- a/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/TimeoutAgentService.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/test/java/dev/langchain4j/cdi/faulttolerance/spi/TimeoutAgentService.java
@@ -1,0 +1,17 @@
+package dev.langchain4j.cdi.faulttolerance.spi;
+
+import dev.langchain4j.cdi.spi.RegisterSimpleAgent;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+// @SuppressWarnings: CDI proxy is created by the portable extension, not by the container directly
+@SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+@RegisterSimpleAgent(chatModelName = "#default", scope = ApplicationScoped.class)
+public interface TimeoutAgentService {
+
+    @Timeout(500)
+    @UserMessage("{question}")
+    String chat(@V("question") String question);
+}

--- a/langchain4j-cdi-mp/langchain4j-cdi-telemetry/src/main/java/dev/langchain4j/cdi/telemetry/GenAITracingTelemetry.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-telemetry/src/main/java/dev/langchain4j/cdi/telemetry/GenAITracingTelemetry.java
@@ -114,31 +114,27 @@ public abstract class GenAITracingTelemetry {
 
         try {
             final Method seedMethod = parameters.getClass().getMethod("seed");
-            if (seedMethod != null) {
-                Object seed = seedMethod.invoke(parameters, (Object[]) null);
-                if (seed != null) span.setAttribute("gen_ai.request.seed", (Integer) seed);
-            }
+            Object seed = seedMethod.invoke(parameters);
+            if (seed instanceof Integer seedValue) span.setAttribute("gen_ai.request.seed", seedValue);
         } catch (NoSuchMethodException
                 | SecurityException
                 | IllegalAccessException
                 | IllegalArgumentException
                 | InvocationTargetException e) {
-            LOGGER.log(Level.WARNING, "The seed() method could not be found.", e);
+            LOGGER.log(Level.FINE, "Failed to invoke optional method seed().", e);
         }
 
         try {
             final Method reasoningEffortMethod = parameters.getClass().getMethod("reasoningEffort");
-            if (reasoningEffortMethod != null) {
-                Object reasoningEffort = reasoningEffortMethod.invoke(parameters, (Object[]) null);
-                if (reasoningEffort != null)
-                    span.setAttribute("gen_ai.request.reasoning.level", (String) reasoningEffort);
-            }
+            Object reasoningEffort = reasoningEffortMethod.invoke(parameters);
+            if (reasoningEffort != null)
+                span.setAttribute("gen_ai.request.reasoning.level", reasoningEffort.toString());
         } catch (NoSuchMethodException
                 | SecurityException
                 | IllegalAccessException
                 | IllegalArgumentException
                 | InvocationTargetException e) {
-            LOGGER.log(Level.WARNING, "The reasoningEffort() method could not be found.", e);
+            LOGGER.log(Level.FINE, "Failed to invoke optional method reasoningEffort().", e);
         }
     }
 


### PR DESCRIPTION
…ations

Add Weld JUnit 5 tests verifying that @ApplyFaultTolerance interceptor binding is correctly applied to agent interfaces annotated with any of the six MicroProfile Fault Tolerance annotations (@Retry, @CircuitBreaker, @Timeout, @Bulkhead, @Fallback, @Asynchronous) and absent on plain agents.

- Extract assertFaultToleranceBinding() helper to eliminate duplication
- Remove hardcoded jakarta.interceptor-api version (managed by jakartaee-bom)
- Clean up GenAITracingTelemetry reflection: remove dead null-checks, use pattern matching for type-safe casts, downgrade log level to FINE