### PR TITLE
refactor(agent): use AgentUtil.buildAgent and add AgenticScopeAccess to CDI factory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,11 +189,12 @@ public interface PipelineAgent {}
 
 **Agent proxy creation:**
 
-`CommonAgentCreator` uses two proxy creation mechanisms:
-- **`cdiAgentInstanceFactory`**: For `@Agent`-annotated simple agents — passed as the 3rd argument to `AgentConfigurator`, delegates to `AgentBuilder.interfacesToImplement()` to include all framework-required interfaces
-- **`createAgentProxy`**: For non-`@Agent` simple agents and HITL — creates JDK proxies with `[userInterface, InternalAgent, AgenticScopeOwner, AgenticScopeAccess]` plus any extra interfaces
+`CommonAgentCreator` uses three proxy creation mechanisms:
+- **`cdiAgentInstanceFactory`**: For `@Agent`-annotated simple agents — passed as the 3rd argument to `AgentConfigurator`, delegates to `AgentBuilder.interfacesToImplement()` to include all framework-required interfaces, plus `AgenticScopeAccess`
+- **`AgentUtil.buildAgent`**: For non-`@Agent` simple agents and `wrapWithAgenticScope` — delegates proxy creation to the LangChain4j framework (since 1.17), which handles the standard interface set internally
+- **`createAgentProxy`**: Used only for HITL agents — creates JDK proxies with `[userInterface, InternalAgent, AgenticScopeOwner, AgenticScopeAccess, HumanInTheLoopHolder]`. This remains a local method because `AgentUtil.buildAgent` does not accept extra interfaces, and HITL agents need the `HumanInTheLoopHolder` marker so that `toAgentExecutor` can retrieve the underlying `HumanInTheLoop` spec
 
-Both mechanisms ensure all agent proxies implement `AgenticScopeAccess` (added in the 1.16.2 upgrade).
+All mechanisms ensure agent proxies implement `AgenticScopeAccess`.
 
 ### Configuration-Based Plugin Creation
 

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
@@ -100,6 +100,7 @@ public class CommonAgentCreator {
             for (Class<?> iface : AgentBuilder.interfacesToImplement(interfaceClass)) {
                 interfaces.add(iface);
             }
+            interfaces.add(AgenticScopeAccess.class);
             for (Class<?> extra : extraInterfaces) {
                 interfaces.add(extra);
             }
@@ -107,6 +108,15 @@ public class CommonAgentCreator {
         };
     }
 
+    /**
+     * Creates a JDK proxy that implements the agent's user interface plus the standard framework interfaces and any
+     * extra interfaces. Used only for HITL agents, which need the additional {@link HumanInTheLoopHolder} marker
+     * interface so that {@link #toAgentExecutor} can retrieve the underlying {@link HumanInTheLoop} spec.
+     * {@link AgentUtil#buildAgent} cannot be used here because it accepts no extra interfaces.
+     *
+     * <p>All other proxy creation paths delegate to {@link AgentUtil#buildAgent} (simple-agent proxies) or to
+     * {@link #cdiAgentInstanceFactory} (CDI-managed {@code @Agent} proxies).
+     */
     @SuppressWarnings("unchecked")
     static <X> X createAgentProxy(Class<X> interfaceClass, InvocationHandler handler, Class<?>... extraInterfaces) {
         Set<Class<?>> interfaces = new LinkedHashSet<>();
@@ -244,7 +254,7 @@ public class CommonAgentCreator {
             }
             return method.invoke(aiService, args);
         };
-        return createAgentProxy(interfaceClass, handler);
+        return AgentUtil.buildAgent(interfaceClass, handler);
     }
 
     private static <X> X buildAiServiceForSimple(

--- a/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/CommonAgentCreatorTest.java
+++ b/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/CommonAgentCreatorTest.java
@@ -1800,6 +1800,7 @@ class CommonAgentCreatorTest {
         for (Class<?> iface : frameworkInterfaces) {
             assertTrue(iface.isInstance(proxy), "Proxy should implement " + iface.getName());
         }
+        assertTrue(proxy instanceof AgenticScopeAccess, "Proxy should implement AgenticScopeAccess");
     }
 
     @Test


### PR DESCRIPTION
Replace createAgentProxy with AgentUtil.buildAgent for simple agent proxies and add AgenticScopeAccess to the cdiAgentInstanceFactory interface list, aligning both proxy creation paths.