### PR TITLE
docs(javadoc): fix all javadoc errors and warnings across the project

### DIFF
--- a/examples/car-booking-mcp/src/main/java/org/wildfly/ai/booking/Booking.java
+++ b/examples/car-booking-mcp/src/main/java/org/wildfly/ai/booking/Booking.java
@@ -3,6 +3,7 @@ package org.wildfly.ai.booking;
 import java.time.LocalDate;
 import java.util.Objects;
 
+/** Car booking details. */
 public class Booking {
 
     private String bookingNumber;
@@ -12,6 +13,16 @@ public class Booking {
     private boolean canceled = false;
     private String carModel;
 
+    /**
+     * Creates a new booking with the given details.
+     *
+     * @param bookingNumber the booking number
+     * @param start the start date
+     * @param end the end date
+     * @param customer the customer
+     * @param canceled whether the booking is canceled
+     * @param carModel the car model
+     */
     public Booking(
             final String bookingNumber,
             final LocalDate start,
@@ -27,50 +38,110 @@ public class Booking {
         this.carModel = carModel;
     }
 
+    /**
+     * Returns the booking number.
+     *
+     * @return the booking number
+     */
     public String getBookingNumber() {
         return this.bookingNumber;
     }
 
+    /**
+     * Returns the start date.
+     *
+     * @return the start date
+     */
     public LocalDate getStart() {
         return this.start;
     }
 
+    /**
+     * Returns the end date.
+     *
+     * @return the end date
+     */
     public LocalDate getEnd() {
         return this.end;
     }
 
+    /**
+     * Returns the customer.
+     *
+     * @return the customer
+     */
     public Customer getCustomer() {
         return this.customer;
     }
 
+    /**
+     * Returns whether the booking is canceled.
+     *
+     * @return {@code true} if the booking is canceled
+     */
     public boolean isCanceled() {
         return this.canceled;
     }
 
+    /**
+     * Returns the car model.
+     *
+     * @return the car model
+     */
     public String getCarModel() {
         return this.carModel;
     }
 
+    /**
+     * Sets the booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public void setBookingNumber(final String bookingNumber) {
         this.bookingNumber = bookingNumber;
     }
 
+    /**
+     * Sets the start date.
+     *
+     * @param start the start date
+     */
     public void setStart(final LocalDate start) {
         this.start = start;
     }
 
+    /**
+     * Sets the end date.
+     *
+     * @param end the end date
+     */
     public void setEnd(final LocalDate end) {
         this.end = end;
     }
 
+    /**
+     * Sets the customer.
+     *
+     * @param customer the customer
+     */
     public void setCustomer(final Customer customer) {
         this.customer = customer;
     }
 
+    /**
+     * Sets whether the booking is canceled.
+     *
+     * @param canceled whether the booking is canceled
+     */
     public void setCanceled(final boolean canceled) {
         this.canceled = canceled;
     }
 
+    /**
+     * Sets the car model.
+     *
+     * @param carModel the car model
+     */
     public void setCarModel(final String carModel) {
         this.carModel = carModel;
     }

--- a/examples/car-booking-mcp/src/main/java/org/wildfly/ai/booking/BookingAlreadyCanceledException.java
+++ b/examples/car-booking-mcp/src/main/java/org/wildfly/ai/booking/BookingAlreadyCanceledException.java
@@ -1,7 +1,13 @@
 package org.wildfly.ai.booking;
 
+/** Thrown when attempting to cancel a booking that has already been canceled. */
 public class BookingAlreadyCanceledException extends RuntimeException {
 
+    /**
+     * Creates a new exception for an already canceled booking.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingAlreadyCanceledException(String bookingNumber) {
         super("Booking " + bookingNumber + " already canceled");
     }

--- a/examples/car-booking-mcp/src/main/java/org/wildfly/ai/booking/BookingCannotBeCanceledException.java
+++ b/examples/car-booking-mcp/src/main/java/org/wildfly/ai/booking/BookingCannotBeCanceledException.java
@@ -1,7 +1,13 @@
 package org.wildfly.ai.booking;
 
+/** Thrown when a booking cannot be canceled due to policy restrictions. */
 public class BookingCannotBeCanceledException extends RuntimeException {
 
+    /**
+     * Creates a new exception for a non-cancelable booking.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingCannotBeCanceledException(String bookingNumber) {
         super("Booking " + bookingNumber + " cannot be canceled");
     }

--- a/examples/car-booking-mcp/src/main/java/org/wildfly/ai/booking/BookingNotFoundException.java
+++ b/examples/car-booking-mcp/src/main/java/org/wildfly/ai/booking/BookingNotFoundException.java
@@ -1,7 +1,13 @@
 package org.wildfly.ai.booking;
 
+/** Thrown when a booking cannot be found. */
 public class BookingNotFoundException extends RuntimeException {
 
+    /**
+     * Creates a new exception for a missing booking.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingNotFoundException(String bookingNumber) {
         super("Booking " + bookingNumber + " not found");
     }

--- a/examples/car-booking-mcp/src/main/java/org/wildfly/ai/booking/BookingService.java
+++ b/examples/car-booking-mcp/src/main/java/org/wildfly/ai/booking/BookingService.java
@@ -14,6 +14,7 @@ import org.wildfly.mcp.api.TextContent;
 import org.wildfly.mcp.api.Tool;
 import org.wildfly.mcp.api.ToolArg;
 
+/** MCP tool and prompt provider for car booking operations. */
 public class BookingService {
 
     private static final Logger log = Logger.getLogger(BookingService.class.getName());
@@ -70,6 +71,9 @@ public class BookingService {
                         "BMW")); // Cancelable
     }
 
+    /** Creates a new BookingService. */
+    public BookingService() {}
+
     // Simulate database accesses
     private Booking checkBookingExists(String bookingNumber, String name, String surname) {
         Booking booking = BOOKINGS.get(bookingNumber);
@@ -81,6 +85,14 @@ public class BookingService {
         return booking;
     }
 
+    /**
+     * Gets booking details given a booking id and customer name and surname.
+     *
+     * @param bookingNumber the booking id
+     * @param name the name of the customer
+     * @param surname the surname of the customer
+     * @return the booking details
+     */
     @Tool(description = "Get booking details given a booking id and customer name and surname")
     public Booking getBookingDetails(
             @ToolArg(description = "The booking id composed of three digits followed by a minus then three digits")
@@ -91,12 +103,24 @@ public class BookingService {
         return checkBookingExists(bookingNumber, name, surname);
     }
 
+    /**
+     * Gets all bookings.
+     *
+     * @return all booking details
+     */
     @Tool(description = "Get All bookings")
     public Collection<Booking> getAllBookingDetails() {
         log.info("DEMO: Calling Tool-getAllBookingDetails");
         return BOOKINGS.values();
     }
 
+    /**
+     * Gets all booking ids for a customer given their name and surname.
+     *
+     * @param name the name of the customer
+     * @param surname the surname of the customer
+     * @return the list of booking ids for the customer
+     */
     @Tool(description = "Get all booking ids for a customer given his name and surname")
     public List<String> getBookingsForCustomer(
             @ToolArg(description = "The name of the customer") String name,
@@ -109,6 +133,11 @@ public class BookingService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Checks whether a booking can be canceled according to the cancellation policy.
+     *
+     * @param booking the booking to check
+     */
     public void checkCancelPolicy(Booking booking) {
         // Reservations can be cancelled up to 7 days prior to the start of the booking
         // period
@@ -121,6 +150,14 @@ public class BookingService {
         }
     }
 
+    /**
+     * Cancels a booking given its booking number and customer name and surname.
+     *
+     * @param bookingNumber the booking id
+     * @param name the name of the customer
+     * @param surname the surname of the customer
+     * @return the canceled booking
+     */
     @Tool(description = "Cancel a booking given its booking number and customer name and surname")
     public Booking cancelBooking(
             @ToolArg(description = "The booking id composed of three digits followed by a minus then three digits")
@@ -137,6 +174,13 @@ public class BookingService {
         return booking;
     }
 
+    /**
+     * Detects fraud for a customer by analyzing booking overlaps.
+     *
+     * @param name the customer's first name
+     * @param surname the customer's surname
+     * @return a prompt message with fraud detection instructions
+     */
     @Prompt(name = "detect-fraud-for-customer", description = "Detect fraud for customer.")
     public PromptMessage detectFraudForCustomer(
             @PromptArg(name = "name", description = "User name.", required = true) String name,

--- a/examples/car-booking-mcp/src/main/java/org/wildfly/ai/booking/Customer.java
+++ b/examples/car-booking-mcp/src/main/java/org/wildfly/ai/booking/Customer.java
@@ -2,28 +2,55 @@ package org.wildfly.ai.booking;
 
 import java.util.Objects;
 
+/** Customer information. */
 public class Customer {
 
     private String name;
     private String surname;
 
+    /**
+     * Creates a new customer.
+     *
+     * @param name the customer's first name
+     * @param surname the customer's surname
+     */
     public Customer(final String name, final String surname) {
         this.name = name;
         this.surname = surname;
     }
 
+    /**
+     * Returns the name.
+     *
+     * @return the customer's first name
+     */
     public String getName() {
         return this.name;
     }
 
+    /**
+     * Returns the surname.
+     *
+     * @return the customer's surname
+     */
     public String getSurname() {
         return this.surname;
     }
 
+    /**
+     * Sets the name.
+     *
+     * @param name the customer's first name
+     */
     public void setName(final String name) {
         this.name = name;
     }
 
+    /**
+     * Sets the surname.
+     *
+     * @param surname the customer's surname
+     */
     public void setSurname(final String surname) {
         this.surname = surname;
     }

--- a/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Booking.java
+++ b/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Booking.java
@@ -3,6 +3,7 @@ package dev.langchain4j.cdi.example.booking;
 import java.time.LocalDate;
 import java.util.Objects;
 
+/** Car booking details. */
 public class Booking {
 
     private String bookingNumber;
@@ -12,18 +13,20 @@ public class Booking {
     private boolean canceled = false;
     private String carModel;
 
-    /** */
+    /** Creates a new booking. */
     public Booking() {
         super();
     }
 
     /**
-     * @param bookingNumber
-     * @param start
-     * @param end
-     * @param customer
-     * @param canceled
-     * @param carModel
+     * Creates a new booking with the given details.
+     *
+     * @param bookingNumber the booking number
+     * @param start the start date
+     * @param end the end date
+     * @param customer the customer
+     * @param canceled whether the booking is canceled
+     * @param carModel the car model
      */
     public Booking(
             String bookingNumber,
@@ -41,62 +44,110 @@ public class Booking {
         this.carModel = carModel;
     }
 
-    /** @return the bookingNumber */
+    /**
+     * Returns the booking number.
+     *
+     * @return the booking number
+     */
     public String getBookingNumber() {
         return bookingNumber;
     }
 
-    /** @param bookingNumber the bookingNumber to set */
+    /**
+     * Sets the booking number.
+     *
+     * @param bookingNumber the booking number to set
+     */
     public void setBookingNumber(String bookingNumber) {
         this.bookingNumber = bookingNumber;
     }
 
-    /** @return the start */
+    /**
+     * Returns the start date.
+     *
+     * @return the start date
+     */
     public LocalDate getStart() {
         return start;
     }
 
-    /** @param start the start to set */
+    /**
+     * Sets the start date.
+     *
+     * @param start the start date to set
+     */
     public void setStart(LocalDate start) {
         this.start = start;
     }
 
-    /** @return the end */
+    /**
+     * Returns the end date.
+     *
+     * @return the end date
+     */
     public LocalDate getEnd() {
         return end;
     }
 
-    /** @param end the end to set */
+    /**
+     * Sets the end date.
+     *
+     * @param end the end date to set
+     */
     public void setEnd(LocalDate end) {
         this.end = end;
     }
 
-    /** @return the customer */
+    /**
+     * Returns the customer.
+     *
+     * @return the customer
+     */
     public Customer getCustomer() {
         return customer;
     }
 
-    /** @param customer the customer to set */
+    /**
+     * Sets the customer.
+     *
+     * @param customer the customer to set
+     */
     public void setCustomer(Customer customer) {
         this.customer = customer;
     }
 
-    /** @return the canceled */
+    /**
+     * Returns whether the booking is canceled.
+     *
+     * @return {@code true} if the booking is canceled
+     */
     public boolean isCanceled() {
         return canceled;
     }
 
-    /** @param canceled the canceled to set */
+    /**
+     * Sets whether the booking is canceled.
+     *
+     * @param canceled {@code true} if the booking is canceled
+     */
     public void setCanceled(boolean canceled) {
         this.canceled = canceled;
     }
 
-    /** @return the carModel */
+    /**
+     * Returns the car model.
+     *
+     * @return the car model
+     */
     public String getCarModel() {
         return carModel;
     }
 
-    /** @param carModel the carModel to set */
+    /**
+     * Sets the car model.
+     *
+     * @param carModel the car model to set
+     */
     public void setCarModel(String carModel) {
         this.carModel = carModel;
     }

--- a/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingAlreadyCanceledException.java
+++ b/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingAlreadyCanceledException.java
@@ -1,7 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking has already been canceled. */
 public class BookingAlreadyCanceledException extends RuntimeException {
 
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingAlreadyCanceledException(String bookingNumber) {
         super("Booking " + bookingNumber + " already canceled");
     }

--- a/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingCannotBeCanceledException.java
+++ b/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingCannotBeCanceledException.java
@@ -1,7 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking cannot be canceled. */
 public class BookingCannotBeCanceledException extends RuntimeException {
 
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingCannotBeCanceledException(String bookingNumber) {
         super("Booking " + bookingNumber + " cannot be canceled");
     }

--- a/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingNotFoundException.java
+++ b/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingNotFoundException.java
@@ -1,6 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking is not found. */
 public class BookingNotFoundException extends RuntimeException {
+
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingNotFoundException(String bookingNumber) {
         super("Booking " + bookingNumber + " not found");
     }

--- a/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingService.java
+++ b/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingService.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+/** Car booking management service with tool methods for AI integration. */
 @ApplicationScoped
 public class BookingService {
 
@@ -16,6 +17,9 @@ public class BookingService {
 
     // Pseudo database
     private static final Map<String, Booking> BOOKINGS = new HashMap<>();
+
+    /** Creates a new booking service. */
+    public BookingService() {}
 
     static {
         // James Bond: hero customer!
@@ -78,6 +82,14 @@ public class BookingService {
         return booking;
     }
 
+    /**
+     * Retrieves booking details.
+     *
+     * @param bookingNumber the booking number
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the booking details
+     */
     @Tool("Get booking details given a booking number and customer name and surname")
     public Booking getBookingDetails(String bookingNumber, String name, String surname) {
         LOGGER.info(
@@ -85,6 +97,13 @@ public class BookingService {
         return checkBookingExists(bookingNumber, name, surname);
     }
 
+    /**
+     * Lists booking IDs for a customer.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the list of booking IDs
+     */
     @Tool("Get all booking ids for a customer given his name and surname")
     public List<String> getBookingsForCustomer(String name, String surname) {
         LOGGER.info("DEMO: Calling Tool-getBookingsForCustomer: " + name + " " + surname);
@@ -95,6 +114,11 @@ public class BookingService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Checks if a booking can be canceled per policy.
+     *
+     * @param booking the booking to check
+     */
     public void checkCancelPolicy(Booking booking) {
 
         // Reservations can be cancelled up to 7 days prior to the start of the booking
@@ -109,6 +133,14 @@ public class BookingService {
         }
     }
 
+    /**
+     * Cancels a booking.
+     *
+     * @param bookingNumber the booking number
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the canceled booking
+     */
     @Tool("Cancel a booking given its booking number and customer name and surname")
     public Booking cancelBooking(String bookingNumber, String name, String surname) {
         LOGGER.info("DEMO: Calling Tool-cancelBooking " + bookingNumber + " for customer: " + name + " " + surname);

--- a/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/CarBookingResource.java
+++ b/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/CarBookingResource.java
@@ -8,6 +8,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 
+/** REST resource for car booking AI services. */
 @ApplicationScoped
 @Path("/car-booking")
 public class CarBookingResource {
@@ -18,6 +19,15 @@ public class CarBookingResource {
     @Inject
     private FraudAiService fraudService;
 
+    /** Creates a new car booking resource. */
+    public CarBookingResource() {}
+
+    /**
+     * Chats with the car booking assistant.
+     *
+     * @param question the question to ask
+     * @return the assistant's response
+     */
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/chat")
@@ -34,6 +44,13 @@ public class CarBookingResource {
         return answer;
     }
 
+    /**
+     * Detects fraud for a customer.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fraud detection response
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/fraud")

--- a/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
+++ b/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
@@ -3,6 +3,7 @@ package dev.langchain4j.cdi.example.booking;
 import dev.langchain4j.cdi.spi.RegisterAIService;
 import dev.langchain4j.service.SystemMessage;
 
+/** AI service for car booking customer support chat. */
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
         tools = BookingService.class,
@@ -11,6 +12,12 @@ import dev.langchain4j.service.SystemMessage;
         chatModelName = "chat-model")
 public interface ChatAiService {
 
+    /**
+     * Sends a question to the assistant and returns the response.
+     *
+     * @param question the question to ask
+     * @return the assistant's response
+     */
     @SystemMessage("""
             You are a customer support agent of a car rental company named 'Miles of Smiles'.
             Before providing information about booking or canceling a booking, you MUST always check:
@@ -23,6 +30,12 @@ public interface ChatAiService {
     // String chat(@V("question") @UserMessage String question);
     String chat(String question);
 
+    /**
+     * Fallback response when the chat service is unavailable.
+     *
+     * @param question the question that was asked
+     * @return the fallback response
+     */
     default String chatFallback(String question) {
         return String.format(
                 "Sorry, I am not able to answer your request %s at the moment. Please try again later.", question);

--- a/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Customer.java
+++ b/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Customer.java
@@ -2,18 +2,21 @@ package dev.langchain4j.cdi.example.booking;
 
 import java.util.Objects;
 
+/** Customer information. */
 public class Customer {
     private String name;
     private String surname;
 
-    /** */
+    /** Creates a new customer. */
     public Customer() {
         super();
     }
 
     /**
-     * @param name
-     * @param surname
+     * Creates a new customer with the given name and surname.
+     *
+     * @param name the customer's first name
+     * @param surname the customer's surname
      */
     public Customer(String name, String surname) {
         super();
@@ -21,22 +24,38 @@ public class Customer {
         this.surname = surname;
     }
 
-    /** @return the name */
+    /**
+     * Returns the name.
+     *
+     * @return the name
+     */
     public String getName() {
         return name;
     }
 
-    /** @param name the name to set */
+    /**
+     * Sets the name.
+     *
+     * @param name the name to set
+     */
     public void setName(String name) {
         this.name = name;
     }
 
-    /** @return the surname */
+    /**
+     * Returns the surname.
+     *
+     * @return the surname
+     */
     public String getSurname() {
         return surname;
     }
 
-    /** @param surname the surname to set */
+    /**
+     * Sets the surname.
+     *
+     * @param surname the surname to set
+     */
     public void setSurname(String surname) {
         this.surname = surname;
     }

--- a/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/DocRagIngestor.java
+++ b/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/DocRagIngestor.java
@@ -18,6 +18,7 @@ import java.io.File;
 import java.util.List;
 import java.util.logging.Logger;
 
+/** Document RAG ingestor for loading car rental terms into the embedding store. */
 @ApplicationScoped
 public class DocRagIngestor {
 
@@ -33,10 +34,18 @@ public class DocRagIngestor {
 
     private File docs = new File(System.getProperty("docragdir"));
 
+    /** Creates a new document RAG ingestor. */
+    public DocRagIngestor() {}
+
     private List<Document> loadDocs() {
         return loadDocuments(docs.getPath(), new TextDocumentParser());
     }
 
+    /**
+     * Ingests car rental terms document into the embedding store.
+     *
+     * @param pointless the CDI event object (unused)
+     */
     public void ingest(@Observes @Initialized(ApplicationScoped.class) Object pointless) {
 
         long start = System.currentTimeMillis();
@@ -54,6 +63,11 @@ public class DocRagIngestor {
                 "DEMO %d documents ingested in %d msec", docs.size(), System.currentTimeMillis() - start));
     }
 
+    /**
+     * Runs the document ingestion as a standalone process.
+     *
+     * @param args the command-line arguments
+     */
     public static void main(String[] args) {
 
         System.out.println(InMemoryEmbeddingStore.class.getInterfaces()[0]);

--- a/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/DummyLLConfig.java
+++ b/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/DummyLLConfig.java
@@ -7,9 +7,14 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/** File-based LLM configuration provider. */
 public class DummyLLConfig extends LLMConfig {
     Properties properties = new Properties();
 
+    /** Creates a new configuration. */
+    public DummyLLConfig() {}
+
+    /** {@inheritDoc} */
     @Override
     public void init() {
         try (FileReader fileReader = new FileReader(System.getProperty("llmconfigfile"))) {
@@ -19,6 +24,7 @@ public class DummyLLConfig extends LLMConfig {
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     public Set<String> getPropertyKeys() {
         return properties.keySet().stream()
@@ -27,6 +33,7 @@ public class DummyLLConfig extends LLMConfig {
                 .collect(Collectors.toSet());
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getValue(String key) {
         return properties.getProperty(key);

--- a/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
+++ b/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
@@ -5,6 +5,7 @@ import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
 
+/** AI service for booking fraud detection. */
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
         contentRetrieverName = "docRagRetriever",
@@ -13,6 +14,13 @@ import dev.langchain4j.service.V;
         tools = BookingService.class)
 public interface FraudAiService {
 
+    /**
+     * Detects fraud for a customer.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fraud detection response
+     */
     @SystemMessage("""
             You are a car booking fraud detection AI for Miles of Smiles.
             You have to detect customer fraud in bookings.
@@ -48,6 +56,13 @@ public interface FraudAiService {
             """)
     FraudResponse detectFraudForCustomer(@V("name") String name, @V("surname") String surname);
 
+    /**
+     * Fallback response when fraud detection is unavailable.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fallback response
+     */
     default FraudResponse fraudFallback(String name, String surname) {
         throw new RuntimeException("Sorry, I am not able to detect fraud for customer " + name + " " + surname
                 + " at the moment. Please try again later.");

--- a/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudResponse.java
+++ b/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudResponse.java
@@ -3,48 +3,84 @@ package dev.langchain4j.cdi.example.booking;
 import java.util.List;
 
 // Warning: Java Record not supported by Google JSON (used by LangChain4J)
+/** Fraud detection response. */
 public class FraudResponse {
     private String customerName;
     private String customerSurname;
     private boolean fraudDetected;
     private List<String> bookingIds;
 
-    /** @return the customerName */
+    /** Creates a new fraud response. */
+    public FraudResponse() {}
+
+    /**
+     * Returns the customer name.
+     *
+     * @return the customer name
+     */
     public String getCustomerName() {
         return customerName;
     }
 
-    /** @param customerName the customerName to set */
+    /**
+     * Sets the customer name.
+     *
+     * @param customerName the customer name to set
+     */
     public void setCustomerName(String customerName) {
         this.customerName = customerName;
     }
 
-    /** @return the customerSurname */
+    /**
+     * Returns the customer surname.
+     *
+     * @return the customer surname
+     */
     public String getCustomerSurname() {
         return customerSurname;
     }
 
-    /** @param customerSurname the customerSurname to set */
+    /**
+     * Sets the customer surname.
+     *
+     * @param customerSurname the customer surname to set
+     */
     public void setCustomerSurname(String customerSurname) {
         this.customerSurname = customerSurname;
     }
 
-    /** @return the fraudDetected */
+    /**
+     * Returns whether fraud was detected.
+     *
+     * @return {@code true} if fraud was detected
+     */
     public boolean isFraudDetected() {
         return fraudDetected;
     }
 
-    /** @param fraudDetected the fraudDetected to set */
+    /**
+     * Sets whether fraud was detected.
+     *
+     * @param fraudDetected {@code true} if fraud was detected
+     */
     public void setFraudDetected(boolean fraudDetected) {
         this.fraudDetected = fraudDetected;
     }
 
-    /** @return the bookingIds */
+    /**
+     * Returns the booking IDs.
+     *
+     * @return the booking IDs
+     */
     public List<String> getBookingIds() {
         return bookingIds;
     }
 
-    /** @param bookingIds the bookingIds to set */
+    /**
+     * Sets the booking IDs.
+     *
+     * @param bookingIds the booking IDs to set
+     */
     public void setBookingIds(List<String> bookingIds) {
         this.bookingIds = bookingIds;
     }

--- a/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/JaxRSApp.java
+++ b/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/JaxRSApp.java
@@ -3,5 +3,10 @@ package dev.langchain4j.cdi.example.booking;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 
+/** JAX-RS application configuration. */
 @ApplicationPath("/api")
-public class JaxRSApp extends Application {}
+public class JaxRSApp extends Application {
+
+    /** Creates a new JAX-RS application. */
+    public JaxRSApp() {}
+}

--- a/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/Booking.java
+++ b/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/Booking.java
@@ -3,6 +3,7 @@ package dev.langchain4j.cdi.example.booking;
 import java.time.LocalDate;
 import java.util.Objects;
 
+/** Car booking details. */
 public class Booking {
 
     private String bookingNumber;
@@ -12,18 +13,20 @@ public class Booking {
     private boolean canceled = false;
     private String carModel;
 
-    /** */
+    /** Creates a new booking. */
     public Booking() {
         super();
     }
 
     /**
-     * @param bookingNumber
-     * @param start
-     * @param end
-     * @param customer
-     * @param canceled
-     * @param carModel
+     * Creates a new booking with the given details.
+     *
+     * @param bookingNumber the booking number
+     * @param start the start date
+     * @param end the end date
+     * @param customer the customer
+     * @param canceled whether the booking is canceled
+     * @param carModel the car model
      */
     public Booking(
             String bookingNumber,
@@ -41,62 +44,110 @@ public class Booking {
         this.carModel = carModel;
     }
 
-    /** @return the bookingNumber */
+    /**
+     * Returns the booking number.
+     *
+     * @return the booking number
+     */
     public String getBookingNumber() {
         return bookingNumber;
     }
 
-    /** @param bookingNumber the bookingNumber to set */
+    /**
+     * Sets the booking number.
+     *
+     * @param bookingNumber the booking number to set
+     */
     public void setBookingNumber(String bookingNumber) {
         this.bookingNumber = bookingNumber;
     }
 
-    /** @return the start */
+    /**
+     * Returns the start date.
+     *
+     * @return the start date
+     */
     public LocalDate getStart() {
         return start;
     }
 
-    /** @param start the start to set */
+    /**
+     * Sets the start date.
+     *
+     * @param start the start date to set
+     */
     public void setStart(LocalDate start) {
         this.start = start;
     }
 
-    /** @return the end */
+    /**
+     * Returns the end date.
+     *
+     * @return the end date
+     */
     public LocalDate getEnd() {
         return end;
     }
 
-    /** @param end the end to set */
+    /**
+     * Sets the end date.
+     *
+     * @param end the end date to set
+     */
     public void setEnd(LocalDate end) {
         this.end = end;
     }
 
-    /** @return the customer */
+    /**
+     * Returns the customer.
+     *
+     * @return the customer
+     */
     public Customer getCustomer() {
         return customer;
     }
 
-    /** @param customer the customer to set */
+    /**
+     * Sets the customer.
+     *
+     * @param customer the customer to set
+     */
     public void setCustomer(Customer customer) {
         this.customer = customer;
     }
 
-    /** @return the canceled */
+    /**
+     * Returns whether the booking is canceled.
+     *
+     * @return {@code true} if the booking is canceled
+     */
     public boolean isCanceled() {
         return canceled;
     }
 
-    /** @param canceled the canceled to set */
+    /**
+     * Sets whether the booking is canceled.
+     *
+     * @param canceled {@code true} if the booking is canceled
+     */
     public void setCanceled(boolean canceled) {
         this.canceled = canceled;
     }
 
-    /** @return the carModel */
+    /**
+     * Returns the car model.
+     *
+     * @return the car model
+     */
     public String getCarModel() {
         return carModel;
     }
 
-    /** @param carModel the carModel to set */
+    /**
+     * Sets the car model.
+     *
+     * @param carModel the car model to set
+     */
     public void setCarModel(String carModel) {
         this.carModel = carModel;
     }

--- a/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/BookingAlreadyCanceledException.java
+++ b/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/BookingAlreadyCanceledException.java
@@ -1,7 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking has already been canceled. */
 public class BookingAlreadyCanceledException extends RuntimeException {
 
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingAlreadyCanceledException(String bookingNumber) {
         super("Booking " + bookingNumber + " already canceled");
     }

--- a/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/BookingCannotBeCanceledException.java
+++ b/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/BookingCannotBeCanceledException.java
@@ -1,7 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking cannot be canceled. */
 public class BookingCannotBeCanceledException extends RuntimeException {
 
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingCannotBeCanceledException(String bookingNumber) {
         super("Booking " + bookingNumber + " cannot be canceled");
     }

--- a/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/BookingNotFoundException.java
+++ b/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/BookingNotFoundException.java
@@ -1,6 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking is not found. */
 public class BookingNotFoundException extends RuntimeException {
+
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingNotFoundException(String bookingNumber) {
         super("Booking " + bookingNumber + " not found");
     }

--- a/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/BookingService.java
+++ b/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/BookingService.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+/** Car booking management service with tool methods for AI integration. */
 @ApplicationScoped
 public class BookingService {
 
@@ -16,6 +17,9 @@ public class BookingService {
 
     // Pseudo database
     private static final Map<String, Booking> BOOKINGS = new HashMap<>();
+
+    /** Creates a new booking service. */
+    public BookingService() {}
 
     static {
         // James Bond: hero customer!
@@ -78,6 +82,14 @@ public class BookingService {
         return booking;
     }
 
+    /**
+     * Retrieves booking details.
+     *
+     * @param bookingNumber the booking number
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the booking details
+     */
     @Tool("Get booking details given a booking number and customer name and surname")
     public Booking getBookingDetails(String bookingNumber, String name, String surname) {
         LOGGER.info(
@@ -85,6 +97,13 @@ public class BookingService {
         return checkBookingExists(bookingNumber, name, surname);
     }
 
+    /**
+     * Lists booking IDs for a customer.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the list of booking IDs
+     */
     @Tool("Get all booking ids for a customer given his name and surname")
     public List<String> getBookingsForCustomer(String name, String surname) {
         LOGGER.info("DEMO: Calling Tool-getBookingsForCustomer: " + name + " " + surname);
@@ -95,6 +114,11 @@ public class BookingService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Checks if a booking can be canceled per policy.
+     *
+     * @param booking the booking to check
+     */
     public void checkCancelPolicy(Booking booking) {
 
         // Reservations can be cancelled up to 7 days prior to the start of the booking
@@ -109,6 +133,14 @@ public class BookingService {
         }
     }
 
+    /**
+     * Cancels a booking.
+     *
+     * @param bookingNumber the booking number
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the canceled booking
+     */
     @Tool("Cancel a booking given its booking number and customer name and surname")
     public Booking cancelBooking(String bookingNumber, String name, String surname) {
         LOGGER.info("DEMO: Calling Tool-cancelBooking " + bookingNumber + " for customer: " + name + " " + surname);

--- a/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/CarBookingResource.java
+++ b/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/CarBookingResource.java
@@ -12,6 +12,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 
+/** REST resource for car booking AI services. */
 @ApplicationScoped
 @Path("/car-booking")
 public class CarBookingResource {
@@ -22,6 +23,15 @@ public class CarBookingResource {
     @Inject
     private FraudAiService fraudService;
 
+    /** Creates a new car booking resource. */
+    public CarBookingResource() {}
+
+    /**
+     * Chats with the car booking assistant.
+     *
+     * @param question the question to ask
+     * @return the assistant's response
+     */
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/chat")
@@ -52,6 +62,13 @@ public class CarBookingResource {
         return answer;
     }
 
+    /**
+     * Detects fraud for a customer.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fraud detection response
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/fraud")

--- a/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
+++ b/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
@@ -2,11 +2,8 @@ package dev.langchain4j.cdi.example.booking;
 
 import dev.langchain4j.cdi.spi.RegisterAIService;
 import dev.langchain4j.service.SystemMessage;
-import java.time.temporal.ChronoUnit;
-import org.eclipse.microprofile.faulttolerance.Fallback;
-import org.eclipse.microprofile.faulttolerance.Retry;
-import org.eclipse.microprofile.faulttolerance.Timeout;
 
+/** AI service for car booking customer support chat. */
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
         tools = BookingService.class,
@@ -15,6 +12,12 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
         chatModelName = "chat-model")
 public interface ChatAiService {
 
+    /**
+     * Sends a question to the assistant and returns the response.
+     *
+     * @param question the question to ask
+     * @return the assistant's response
+     */
     @SystemMessage("""
             You are a customer support agent of a car rental company named 'Miles of Smiles'.
             Before providing information about booking or canceling a booking, you MUST always check:
@@ -24,24 +27,15 @@ public interface ChatAiService {
             Any cancelation request must comply with cancellation policy both for the delay and the duration.
             Today is {{current_date}}.
             """)
-    @Timeout(unit = ChronoUnit.MINUTES, value = 5)
-    @Retry(
-            abortOn = {
-                BookingCannotBeCanceledException.class,
-                BookingAlreadyCanceledException.class,
-                BookingNotFoundException.class
-            },
-            maxRetries = 2)
-    @Fallback(
-            fallbackMethod = "chatFallback",
-            skipOn = {
-                BookingCannotBeCanceledException.class,
-                BookingAlreadyCanceledException.class,
-                BookingNotFoundException.class
-            })
     // String chat(@V("question") @UserMessage String question);
     String chat(String question);
 
+    /**
+     * Fallback response when the chat service is unavailable.
+     *
+     * @param question the question that was asked
+     * @return the fallback response
+     */
     default String chatFallback(String question) {
         return String.format(
                 "Sorry, I am not able to answer your request %s at the moment. Please try again later.", question);

--- a/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/Customer.java
+++ b/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/Customer.java
@@ -2,18 +2,21 @@ package dev.langchain4j.cdi.example.booking;
 
 import java.util.Objects;
 
+/** Customer information. */
 public class Customer {
     private String name;
     private String surname;
 
-    /** */
+    /** Creates a new customer. */
     public Customer() {
         super();
     }
 
     /**
-     * @param name
-     * @param surname
+     * Creates a new customer with the given name and surname.
+     *
+     * @param name the customer's first name
+     * @param surname the customer's surname
      */
     public Customer(String name, String surname) {
         super();
@@ -21,22 +24,38 @@ public class Customer {
         this.surname = surname;
     }
 
-    /** @return the name */
+    /**
+     * Returns the name.
+     *
+     * @return the name
+     */
     public String getName() {
         return name;
     }
 
-    /** @param name the name to set */
+    /**
+     * Sets the name.
+     *
+     * @param name the name to set
+     */
     public void setName(String name) {
         this.name = name;
     }
 
-    /** @return the surname */
+    /**
+     * Returns the surname.
+     *
+     * @return the surname
+     */
     public String getSurname() {
         return surname;
     }
 
-    /** @param surname the surname to set */
+    /**
+     * Sets the surname.
+     *
+     * @param surname the surname to set
+     */
     public void setSurname(String surname) {
         this.surname = surname;
     }

--- a/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/DocRagIngestor.java
+++ b/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/DocRagIngestor.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.logging.Logger;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+/** Document RAG ingestor for loading car rental terms into the embedding store. */
 @ApplicationScoped
 public class DocRagIngestor {
 
@@ -37,10 +38,18 @@ public class DocRagIngestor {
     @ConfigProperty(name = "app.docs-for-rag.dir")
     private File docs;
 
+    /** Creates a new document RAG ingestor. */
+    public DocRagIngestor() {}
+
     private List<Document> loadDocs() {
         return loadDocuments(docs.getPath(), new TextDocumentParser());
     }
 
+    /**
+     * Ingests car rental terms document into the embedding store.
+     *
+     * @param pointless the CDI event object (unused)
+     */
     public void ingest(@Observes @Initialized(ApplicationScoped.class) Object pointless) {
 
         long start = System.currentTimeMillis();
@@ -58,6 +67,11 @@ public class DocRagIngestor {
                 "DEMO %d documents ingested in %d msec", docs.size(), System.currentTimeMillis() - start));
     }
 
+    /**
+     * Runs the document ingestion as a standalone process.
+     *
+     * @param args the command-line arguments
+     */
     public static void main(String[] args) {
 
         System.out.println(InMemoryEmbeddingStore.class.getInterfaces()[0]);

--- a/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
+++ b/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
@@ -4,11 +4,8 @@ import dev.langchain4j.cdi.spi.RegisterAIService;
 import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
-import java.time.temporal.ChronoUnit;
-import org.eclipse.microprofile.faulttolerance.Fallback;
-import org.eclipse.microprofile.faulttolerance.Retry;
-import org.eclipse.microprofile.faulttolerance.Timeout;
 
+/** AI service for booking fraud detection. */
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
         contentRetrieverName = "docRagRetriever",
@@ -17,6 +14,13 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
         tools = BookingService.class)
 public interface FraudAiService {
 
+    /**
+     * Detects fraud for a customer.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fraud detection response
+     */
     @SystemMessage("""
             You are a car booking fraud detection AI for Miles of Smiles.
             You have to detect customer fraud in bookings.
@@ -50,11 +54,15 @@ public interface FraudAiService {
 
             You must not wrap JSON response in backticks, markdown, or in any other way, but return it as plain text.
             """)
-    @Timeout(unit = ChronoUnit.MINUTES, value = 5)
-    @Retry(maxRetries = 2)
-    @Fallback(fallbackMethod = "fraudFallback")
     FraudResponse detectFraudForCustomer(@V("name") String name, @V("surname") String surname);
 
+    /**
+     * Fallback response when fraud detection is unavailable.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fallback response
+     */
     default FraudResponse fraudFallback(String name, String surname) {
         throw new RuntimeException("Sorry, I am not able to detect fraud for customer " + name + " " + surname
                 + " at the moment. Please try again later.");

--- a/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/FraudResponse.java
+++ b/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/FraudResponse.java
@@ -3,48 +3,84 @@ package dev.langchain4j.cdi.example.booking;
 import java.util.List;
 
 // Warning: Java Record not supported by Google JSON (used by LangChain4J)
+/** Fraud detection response. */
 public class FraudResponse {
     private String customerName;
     private String customerSurname;
     private boolean fraudDetected;
     private List<String> bookingIds;
 
-    /** @return the customerName */
+    /** Creates a new fraud response. */
+    public FraudResponse() {}
+
+    /**
+     * Returns the customer name.
+     *
+     * @return the customer name
+     */
     public String getCustomerName() {
         return customerName;
     }
 
-    /** @param customerName the customerName to set */
+    /**
+     * Sets the customer name.
+     *
+     * @param customerName the customer name to set
+     */
     public void setCustomerName(String customerName) {
         this.customerName = customerName;
     }
 
-    /** @return the customerSurname */
+    /**
+     * Returns the customer surname.
+     *
+     * @return the customer surname
+     */
     public String getCustomerSurname() {
         return customerSurname;
     }
 
-    /** @param customerSurname the customerSurname to set */
+    /**
+     * Sets the customer surname.
+     *
+     * @param customerSurname the customer surname to set
+     */
     public void setCustomerSurname(String customerSurname) {
         this.customerSurname = customerSurname;
     }
 
-    /** @return the fraudDetected */
+    /**
+     * Returns whether fraud was detected.
+     *
+     * @return {@code true} if fraud was detected
+     */
     public boolean isFraudDetected() {
         return fraudDetected;
     }
 
-    /** @param fraudDetected the fraudDetected to set */
+    /**
+     * Sets whether fraud was detected.
+     *
+     * @param fraudDetected {@code true} if fraud was detected
+     */
     public void setFraudDetected(boolean fraudDetected) {
         this.fraudDetected = fraudDetected;
     }
 
-    /** @return the bookingIds */
+    /**
+     * Returns the booking IDs.
+     *
+     * @return the booking IDs
+     */
     public List<String> getBookingIds() {
         return bookingIds;
     }
 
-    /** @param bookingIds the bookingIds to set */
+    /**
+     * Sets the booking IDs.
+     *
+     * @param bookingIds the booking IDs to set
+     */
     public void setBookingIds(List<String> bookingIds) {
         this.bookingIds = bookingIds;
     }

--- a/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Booking.java
+++ b/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Booking.java
@@ -3,6 +3,7 @@ package dev.langchain4j.cdi.example.booking;
 import java.time.LocalDate;
 import java.util.Objects;
 
+/** Car booking details. */
 public class Booking {
 
     private String bookingNumber;
@@ -12,18 +13,20 @@ public class Booking {
     private boolean canceled = false;
     private String carModel;
 
-    /** */
+    /** Creates a new booking. */
     public Booking() {
         super();
     }
 
     /**
-     * @param bookingNumber
-     * @param start
-     * @param end
-     * @param customer
-     * @param canceled
-     * @param carModel
+     * Creates a new booking with the given details.
+     *
+     * @param bookingNumber the booking number
+     * @param start the start date
+     * @param end the end date
+     * @param customer the customer
+     * @param canceled whether the booking is canceled
+     * @param carModel the car model
      */
     public Booking(
             String bookingNumber,
@@ -41,62 +44,110 @@ public class Booking {
         this.carModel = carModel;
     }
 
-    /** @return the bookingNumber */
+    /**
+     * Returns the booking number.
+     *
+     * @return the booking number
+     */
     public String getBookingNumber() {
         return bookingNumber;
     }
 
-    /** @param bookingNumber the bookingNumber to set */
+    /**
+     * Sets the booking number.
+     *
+     * @param bookingNumber the booking number to set
+     */
     public void setBookingNumber(String bookingNumber) {
         this.bookingNumber = bookingNumber;
     }
 
-    /** @return the start */
+    /**
+     * Returns the start date.
+     *
+     * @return the start date
+     */
     public LocalDate getStart() {
         return start;
     }
 
-    /** @param start the start to set */
+    /**
+     * Sets the start date.
+     *
+     * @param start the start date to set
+     */
     public void setStart(LocalDate start) {
         this.start = start;
     }
 
-    /** @return the end */
+    /**
+     * Returns the end date.
+     *
+     * @return the end date
+     */
     public LocalDate getEnd() {
         return end;
     }
 
-    /** @param end the end to set */
+    /**
+     * Sets the end date.
+     *
+     * @param end the end date to set
+     */
     public void setEnd(LocalDate end) {
         this.end = end;
     }
 
-    /** @return the customer */
+    /**
+     * Returns the customer.
+     *
+     * @return the customer
+     */
     public Customer getCustomer() {
         return customer;
     }
 
-    /** @param customer the customer to set */
+    /**
+     * Sets the customer.
+     *
+     * @param customer the customer to set
+     */
     public void setCustomer(Customer customer) {
         this.customer = customer;
     }
 
-    /** @return the canceled */
+    /**
+     * Returns whether the booking is canceled.
+     *
+     * @return {@code true} if the booking is canceled
+     */
     public boolean isCanceled() {
         return canceled;
     }
 
-    /** @param canceled the canceled to set */
+    /**
+     * Sets whether the booking is canceled.
+     *
+     * @param canceled {@code true} if the booking is canceled
+     */
     public void setCanceled(boolean canceled) {
         this.canceled = canceled;
     }
 
-    /** @return the carModel */
+    /**
+     * Returns the car model.
+     *
+     * @return the car model
+     */
     public String getCarModel() {
         return carModel;
     }
 
-    /** @param carModel the carModel to set */
+    /**
+     * Sets the car model.
+     *
+     * @param carModel the car model to set
+     */
     public void setCarModel(String carModel) {
         this.carModel = carModel;
     }

--- a/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingAlreadyCanceledException.java
+++ b/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingAlreadyCanceledException.java
@@ -1,7 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking has already been canceled. */
 public class BookingAlreadyCanceledException extends RuntimeException {
 
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingAlreadyCanceledException(String bookingNumber) {
         super("Booking " + bookingNumber + " already canceled");
     }

--- a/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingCannotBeCanceledException.java
+++ b/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingCannotBeCanceledException.java
@@ -1,7 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking cannot be canceled. */
 public class BookingCannotBeCanceledException extends RuntimeException {
 
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingCannotBeCanceledException(String bookingNumber) {
         super("Booking " + bookingNumber + " cannot be canceled");
     }

--- a/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingNotFoundException.java
+++ b/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingNotFoundException.java
@@ -1,6 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking is not found. */
 public class BookingNotFoundException extends RuntimeException {
+
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingNotFoundException(String bookingNumber) {
         super("Booking " + bookingNumber + " not found");
     }

--- a/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingService.java
+++ b/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingService.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+/** Car booking management service with tool methods for AI integration. */
 @ApplicationScoped
 public class BookingService {
 
@@ -16,6 +17,9 @@ public class BookingService {
 
     // Pseudo database
     private static final Map<String, Booking> BOOKINGS = new HashMap<>();
+
+    /** Creates a new booking service. */
+    public BookingService() {}
 
     static {
         // James Bond: hero customer!
@@ -78,6 +82,14 @@ public class BookingService {
         return booking;
     }
 
+    /**
+     * Retrieves booking details.
+     *
+     * @param bookingNumber the booking number
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the booking details
+     */
     @Tool("Get booking details given a booking number and customer name and surname")
     public Booking getBookingDetails(String bookingNumber, String name, String surname) {
         LOGGER.info(
@@ -85,6 +97,13 @@ public class BookingService {
         return checkBookingExists(bookingNumber, name, surname);
     }
 
+    /**
+     * Lists booking IDs for a customer.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the list of booking IDs
+     */
     @Tool("Get all booking ids for a customer given his name and surname")
     public List<String> getBookingsForCustomer(String name, String surname) {
         LOGGER.info("DEMO: Calling Tool-getBookingsForCustomer: " + name + " " + surname);
@@ -95,6 +114,11 @@ public class BookingService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Checks if a booking can be canceled per policy.
+     *
+     * @param booking the booking to check
+     */
     public void checkCancelPolicy(Booking booking) {
 
         // Reservations can be cancelled up to 7 days prior to the start of the booking
@@ -109,6 +133,14 @@ public class BookingService {
         }
     }
 
+    /**
+     * Cancels a booking.
+     *
+     * @param bookingNumber the booking number
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the canceled booking
+     */
     @Tool("Cancel a booking given its booking number and customer name and surname")
     public Booking cancelBooking(String bookingNumber, String name, String surname) {
         LOGGER.info("DEMO: Calling Tool-cancelBooking " + bookingNumber + " for customer: " + name + " " + surname);

--- a/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/CarBookingResource.java
+++ b/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/CarBookingResource.java
@@ -12,6 +12,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 
+/** REST resource for car booking AI services. */
 @ApplicationScoped
 @Path("/car-booking")
 public class CarBookingResource {
@@ -22,6 +23,15 @@ public class CarBookingResource {
     @Inject
     private FraudAiService fraudService;
 
+    /** Creates a new car booking resource. */
+    public CarBookingResource() {}
+
+    /**
+     * Chats with the car booking assistant.
+     *
+     * @param question the question to ask
+     * @return the assistant's response
+     */
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/chat")
@@ -52,6 +62,13 @@ public class CarBookingResource {
         return answer;
     }
 
+    /**
+     * Detects fraud for a customer.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fraud detection response
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/fraud")

--- a/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
+++ b/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
@@ -7,6 +7,7 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
+/** AI service for car booking customer support chat. */
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
         tools = BookingService.class,
@@ -15,6 +16,12 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
         chatModelName = "chat-model")
 public interface ChatAiService {
 
+    /**
+     * Sends a question to the assistant and returns the response.
+     *
+     * @param question the question to ask
+     * @return the assistant's response
+     */
     @SystemMessage("""
             You are a customer support agent of a car rental company named 'Miles of Smiles'.
             Before providing information about booking or canceling a booking, you MUST always check:
@@ -42,6 +49,12 @@ public interface ChatAiService {
     // String chat(@V("question") @UserMessage String question);
     String chat(String question);
 
+    /**
+     * Fallback response when the chat service is unavailable.
+     *
+     * @param question the question that was asked
+     * @return the fallback response
+     */
     default String chatFallback(String question) {
         return String.format(
                 "Sorry, I am not able to answer your request %s at the moment. Please try again later.", question);

--- a/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Customer.java
+++ b/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Customer.java
@@ -2,18 +2,21 @@ package dev.langchain4j.cdi.example.booking;
 
 import java.util.Objects;
 
+/** Customer information. */
 public class Customer {
     private String name;
     private String surname;
 
-    /** */
+    /** Creates a new customer. */
     public Customer() {
         super();
     }
 
     /**
-     * @param name
-     * @param surname
+     * Creates a new customer with the given name and surname.
+     *
+     * @param name the customer's first name
+     * @param surname the customer's surname
      */
     public Customer(String name, String surname) {
         super();
@@ -21,22 +24,38 @@ public class Customer {
         this.surname = surname;
     }
 
-    /** @return the name */
+    /**
+     * Returns the name.
+     *
+     * @return the name
+     */
     public String getName() {
         return name;
     }
 
-    /** @param name the name to set */
+    /**
+     * Sets the name.
+     *
+     * @param name the name to set
+     */
     public void setName(String name) {
         this.name = name;
     }
 
-    /** @return the surname */
+    /**
+     * Returns the surname.
+     *
+     * @return the surname
+     */
     public String getSurname() {
         return surname;
     }
 
-    /** @param surname the surname to set */
+    /**
+     * Sets the surname.
+     *
+     * @param surname the surname to set
+     */
     public void setSurname(String surname) {
         this.surname = surname;
     }

--- a/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/DocRagIngestor.java
+++ b/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/DocRagIngestor.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.logging.Logger;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+/** Document RAG ingestor for loading car rental terms into the embedding store. */
 @ApplicationScoped
 public class DocRagIngestor {
 
@@ -37,10 +38,18 @@ public class DocRagIngestor {
     @ConfigProperty(name = "app.docs-for-rag.dir")
     private File docs;
 
+    /** Creates a new document RAG ingestor. */
+    public DocRagIngestor() {}
+
     private List<Document> loadDocs() {
         return loadDocuments(docs.getPath(), new TextDocumentParser());
     }
 
+    /**
+     * Ingests car rental terms document into the embedding store.
+     *
+     * @param pointless the CDI event object (unused)
+     */
     public void ingest(@Observes @Initialized(ApplicationScoped.class) Object pointless) {
 
         long start = System.currentTimeMillis();
@@ -58,6 +67,11 @@ public class DocRagIngestor {
                 "DEMO %d documents ingested in %d msec", docs.size(), System.currentTimeMillis() - start));
     }
 
+    /**
+     * Runs the document ingestion as a standalone process.
+     *
+     * @param args the command-line arguments
+     */
     public static void main(String[] args) {
 
         System.out.println(InMemoryEmbeddingStore.class.getInterfaces()[0]);

--- a/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
+++ b/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
@@ -9,6 +9,7 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
+/** AI service for booking fraud detection. */
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
         contentRetrieverName = "docRagRetriever",
@@ -17,6 +18,13 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
         tools = BookingService.class)
 public interface FraudAiService {
 
+    /**
+     * Detects fraud for a customer.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fraud detection response
+     */
     @SystemMessage("""
             You are a car booking fraud detection AI for Miles of Smiles.
             You have to detect customer fraud in bookings.
@@ -55,6 +63,13 @@ public interface FraudAiService {
     @Fallback(fallbackMethod = "fraudFallback")
     FraudResponse detectFraudForCustomer(@V("name") String name, @V("surname") String surname);
 
+    /**
+     * Fallback response when fraud detection is unavailable.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fallback response
+     */
     default FraudResponse fraudFallback(String name, String surname) {
         throw new RuntimeException("Sorry, I am not able to detect fraud for customer " + name + " " + surname
                 + " at the moment. Please try again later.");

--- a/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudResponse.java
+++ b/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudResponse.java
@@ -3,48 +3,84 @@ package dev.langchain4j.cdi.example.booking;
 import java.util.List;
 
 // Warning: Java Record not supported by Google JSON (used by LangChain4J)
+/** Fraud detection response. */
 public class FraudResponse {
     private String customerName;
     private String customerSurname;
     private boolean fraudDetected;
     private List<String> bookingIds;
 
-    /** @return the customerName */
+    /** Creates a new fraud response. */
+    public FraudResponse() {}
+
+    /**
+     * Returns the customer name.
+     *
+     * @return the customer name
+     */
     public String getCustomerName() {
         return customerName;
     }
 
-    /** @param customerName the customerName to set */
+    /**
+     * Sets the customer name.
+     *
+     * @param customerName the customer name to set
+     */
     public void setCustomerName(String customerName) {
         this.customerName = customerName;
     }
 
-    /** @return the customerSurname */
+    /**
+     * Returns the customer surname.
+     *
+     * @return the customer surname
+     */
     public String getCustomerSurname() {
         return customerSurname;
     }
 
-    /** @param customerSurname the customerSurname to set */
+    /**
+     * Sets the customer surname.
+     *
+     * @param customerSurname the customer surname to set
+     */
     public void setCustomerSurname(String customerSurname) {
         this.customerSurname = customerSurname;
     }
 
-    /** @return the fraudDetected */
+    /**
+     * Returns whether fraud was detected.
+     *
+     * @return {@code true} if fraud was detected
+     */
     public boolean isFraudDetected() {
         return fraudDetected;
     }
 
-    /** @param fraudDetected the fraudDetected to set */
+    /**
+     * Sets whether fraud was detected.
+     *
+     * @param fraudDetected {@code true} if fraud was detected
+     */
     public void setFraudDetected(boolean fraudDetected) {
         this.fraudDetected = fraudDetected;
     }
 
-    /** @return the bookingIds */
+    /**
+     * Returns the booking IDs.
+     *
+     * @return the booking IDs
+     */
     public List<String> getBookingIds() {
         return bookingIds;
     }
 
-    /** @param bookingIds the bookingIds to set */
+    /**
+     * Sets the booking IDs.
+     *
+     * @param bookingIds the booking IDs to set
+     */
     public void setBookingIds(List<String> bookingIds) {
         this.bookingIds = bookingIds;
     }

--- a/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/BookingAlreadyCanceledException.java
+++ b/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/BookingAlreadyCanceledException.java
@@ -1,7 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking has already been canceled. */
 public class BookingAlreadyCanceledException extends RuntimeException {
 
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingAlreadyCanceledException(String bookingNumber) {
         super("Booking " + bookingNumber + " already canceled");
     }

--- a/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/BookingCannotBeCanceledException.java
+++ b/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/BookingCannotBeCanceledException.java
@@ -1,7 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking cannot be canceled. */
 public class BookingCannotBeCanceledException extends RuntimeException {
 
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingCannotBeCanceledException(String bookingNumber) {
         super("Booking " + bookingNumber + " cannot be canceled");
     }

--- a/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/BookingNotFoundException.java
+++ b/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/BookingNotFoundException.java
@@ -1,6 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking is not found. */
 public class BookingNotFoundException extends RuntimeException {
+
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingNotFoundException(String bookingNumber) {
         super("Booking " + bookingNumber + " not found");
     }

--- a/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/CarBookingResource.java
+++ b/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/CarBookingResource.java
@@ -11,6 +11,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 
+/** REST resource for car booking AI services. */
 @ApplicationScoped
 @Path("/car-booking")
 public class CarBookingResource {
@@ -21,6 +22,15 @@ public class CarBookingResource {
     @Inject
     private FraudAiService fraudService;
 
+    /** Creates a new car booking resource. */
+    public CarBookingResource() {}
+
+    /**
+     * Chats with the car booking assistant.
+     *
+     * @param question the question to ask
+     * @return the assistant's response
+     */
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/chat")
@@ -40,6 +50,13 @@ public class CarBookingResource {
         return answer;
     }
 
+    /**
+     * Detects fraud for a customer.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fraud detection response
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/fraud")

--- a/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
+++ b/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
@@ -8,6 +8,7 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
+/** AI service for car booking customer support chat. */
 // @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
         chatModelName = "chat-model",
@@ -17,6 +18,12 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
         chatMemoryName = "chat-ai-service-memory")
 public interface ChatAiService {
 
+    /**
+     * Sends a question to the assistant and returns the response.
+     *
+     * @param question the question to ask
+     * @return the assistant's response
+     */
     @SystemMessage("""
             You are a customer support agent of a car rental company named 'Miles of Smiles'.
             Before providing information about booking or canceling a booking, you MUST always check:
@@ -43,6 +50,12 @@ public interface ChatAiService {
             })
     String chat(String question);
 
+    /**
+     * Fallback response when the chat service is unavailable.
+     *
+     * @param question the question that was asked
+     * @return the fallback response
+     */
     default String chatFallback(String question) {
         return String.format(
                 "Sorry, I am not able to answer your request %s at the moment. Please try again later.", question);

--- a/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/DocRagIngestor.java
+++ b/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/DocRagIngestor.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.logging.Logger;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+/** Document RAG ingestor for loading car rental terms into the embedding store. */
 @ApplicationScoped
 public class DocRagIngestor {
 
@@ -38,10 +39,18 @@ public class DocRagIngestor {
     @ConfigProperty(name = "app.docs-for-rag.dir")
     private File docs;
 
+    /** Creates a new document RAG ingestor. */
+    public DocRagIngestor() {}
+
     private List<Document> loadDocs() {
         return loadDocuments(docs.getPath(), new TextDocumentParser());
     }
 
+    /**
+     * Ingests car rental terms document into the embedding store.
+     *
+     * @param pointless the CDI event object (unused)
+     */
     public void ingest(@Observes @Initialized(ApplicationScoped.class) Object pointless) {
 
         long start = System.currentTimeMillis();

--- a/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/DummyLLConfig.java
+++ b/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/DummyLLConfig.java
@@ -7,10 +7,15 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/** File-based LLM configuration provider. */
 @SuppressWarnings("unused")
 public class DummyLLConfig extends LLMConfig {
     Properties properties = new Properties();
 
+    /** Creates a new configuration. */
+    public DummyLLConfig() {}
+
+    /** {@inheritDoc} */
     @Override
     public void init() {
         try (FileReader fileReader = new FileReader(System.getProperty("llmconfigfile"))) {
@@ -20,6 +25,7 @@ public class DummyLLConfig extends LLMConfig {
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     public Set<String> getPropertyKeys() {
         return properties.keySet().stream()
@@ -28,6 +34,7 @@ public class DummyLLConfig extends LLMConfig {
                 .collect(Collectors.toSet());
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getValue(String key) {
         return properties.getProperty(key);

--- a/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
+++ b/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
@@ -5,6 +5,7 @@ import dev.langchain4j.service.SystemMessage;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
 
+/** AI service for booking fraud detection. */
 @RegisterAIService(
         contentRetrieverName = "docRagRetriever",
         chatMemoryName = "fraud-ai-service-memory",
@@ -12,6 +13,13 @@ import dev.langchain4j.service.V;
         toolProviderName = "mcp")
 public interface FraudAiService {
 
+    /**
+     * Detects fraud for a customer.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fraud detection response
+     */
     @SystemMessage("""
             You are a car booking fraud detection AI for Miles of Smiles.
             You have to detect customer fraud in bookings.
@@ -47,6 +55,13 @@ public interface FraudAiService {
             """)
     FraudResponse detectFraudForCustomer(@V("name") String name, @V("surname") String surname);
 
+    /**
+     * Fallback response when fraud detection is unavailable.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fallback response
+     */
     default FraudResponse fraudFallback(String name, String surname) {
         throw new RuntimeException("Sorry, I am not able to detect fraud for customer " + name + " " + surname
                 + " at the moment. Please try again later.");

--- a/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/FraudResponse.java
+++ b/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/FraudResponse.java
@@ -3,48 +3,84 @@ package dev.langchain4j.cdi.example.booking;
 import java.util.List;
 
 // Warning: Java Record not supported by Google JSON (used by LangChain4J)
+/** Fraud detection response. */
 public class FraudResponse {
     private String customerName;
     private String customerSurname;
     private boolean fraudDetected;
     private List<String> bookingIds;
 
-    /** @return the customerName */
+    /** Creates a new fraud response. */
+    public FraudResponse() {}
+
+    /**
+     * Returns the customer name.
+     *
+     * @return the customer name
+     */
     public String getCustomerName() {
         return customerName;
     }
 
-    /** @param customerName the customerName to set */
+    /**
+     * Sets the customer name.
+     *
+     * @param customerName the customer name to set
+     */
     public void setCustomerName(String customerName) {
         this.customerName = customerName;
     }
 
-    /** @return the customerSurname */
+    /**
+     * Returns the customer surname.
+     *
+     * @return the customer surname
+     */
     public String getCustomerSurname() {
         return customerSurname;
     }
 
-    /** @param customerSurname the customerSurname to set */
+    /**
+     * Sets the customer surname.
+     *
+     * @param customerSurname the customer surname to set
+     */
     public void setCustomerSurname(String customerSurname) {
         this.customerSurname = customerSurname;
     }
 
-    /** @return the fraudDetected */
+    /**
+     * Returns whether fraud was detected.
+     *
+     * @return {@code true} if fraud was detected
+     */
     public boolean isFraudDetected() {
         return fraudDetected;
     }
 
-    /** @param fraudDetected the fraudDetected to set */
+    /**
+     * Sets whether fraud was detected.
+     *
+     * @param fraudDetected {@code true} if fraud was detected
+     */
     public void setFraudDetected(boolean fraudDetected) {
         this.fraudDetected = fraudDetected;
     }
 
-    /** @return the bookingIds */
+    /**
+     * Returns the booking IDs.
+     *
+     * @return the booking IDs
+     */
     public List<String> getBookingIds() {
         return bookingIds;
     }
 
-    /** @param bookingIds the bookingIds to set */
+    /**
+     * Sets the booking IDs.
+     *
+     * @param bookingIds the booking IDs to set
+     */
     public void setBookingIds(List<String> bookingIds) {
         this.bookingIds = bookingIds;
     }

--- a/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/JaxRSApp.java
+++ b/examples/liberty-car-booking-mcp/src/main/java/dev/langchain4j/cdi/example/booking/JaxRSApp.java
@@ -3,5 +3,10 @@ package dev.langchain4j.cdi.example.booking;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 
+/** JAX-RS application configuration. */
 @ApplicationPath("/api")
-public class JaxRSApp extends Application {}
+public class JaxRSApp extends Application {
+
+    /** Creates a new JAX-RS application. */
+    public JaxRSApp() {}
+}

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Booking.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Booking.java
@@ -3,6 +3,7 @@ package dev.langchain4j.cdi.example.booking;
 import java.time.LocalDate;
 import java.util.Objects;
 
+/** Car booking details. */
 public class Booking {
 
     private String bookingNumber;
@@ -12,18 +13,20 @@ public class Booking {
     private boolean canceled = false;
     private String carModel;
 
-    /** */
+    /** Creates a new booking. */
     public Booking() {
         super();
     }
 
     /**
-     * @param bookingNumber
-     * @param start
-     * @param end
-     * @param customer
-     * @param canceled
-     * @param carModel
+     * Creates a new booking with the given details.
+     *
+     * @param bookingNumber the booking number
+     * @param start the start date
+     * @param end the end date
+     * @param customer the customer
+     * @param canceled whether the booking is canceled
+     * @param carModel the car model
      */
     public Booking(
             String bookingNumber,
@@ -41,62 +44,110 @@ public class Booking {
         this.carModel = carModel;
     }
 
-    /** @return the bookingNumber */
+    /**
+     * Returns the booking number.
+     *
+     * @return the booking number
+     */
     public String getBookingNumber() {
         return bookingNumber;
     }
 
-    /** @param bookingNumber the bookingNumber to set */
+    /**
+     * Sets the booking number.
+     *
+     * @param bookingNumber the booking number to set
+     */
     public void setBookingNumber(String bookingNumber) {
         this.bookingNumber = bookingNumber;
     }
 
-    /** @return the start */
+    /**
+     * Returns the start date.
+     *
+     * @return the start date
+     */
     public LocalDate getStart() {
         return start;
     }
 
-    /** @param start the start to set */
+    /**
+     * Sets the start date.
+     *
+     * @param start the start date to set
+     */
     public void setStart(LocalDate start) {
         this.start = start;
     }
 
-    /** @return the end */
+    /**
+     * Returns the end date.
+     *
+     * @return the end date
+     */
     public LocalDate getEnd() {
         return end;
     }
 
-    /** @param end the end to set */
+    /**
+     * Sets the end date.
+     *
+     * @param end the end date to set
+     */
     public void setEnd(LocalDate end) {
         this.end = end;
     }
 
-    /** @return the customer */
+    /**
+     * Returns the customer.
+     *
+     * @return the customer
+     */
     public Customer getCustomer() {
         return customer;
     }
 
-    /** @param customer the customer to set */
+    /**
+     * Sets the customer.
+     *
+     * @param customer the customer to set
+     */
     public void setCustomer(Customer customer) {
         this.customer = customer;
     }
 
-    /** @return the canceled */
+    /**
+     * Returns whether the booking is canceled.
+     *
+     * @return {@code true} if the booking is canceled
+     */
     public boolean isCanceled() {
         return canceled;
     }
 
-    /** @param canceled the canceled to set */
+    /**
+     * Sets whether the booking is canceled.
+     *
+     * @param canceled {@code true} if the booking is canceled
+     */
     public void setCanceled(boolean canceled) {
         this.canceled = canceled;
     }
 
-    /** @return the carModel */
+    /**
+     * Returns the car model.
+     *
+     * @return the car model
+     */
     public String getCarModel() {
         return carModel;
     }
 
-    /** @param carModel the carModel to set */
+    /**
+     * Sets the car model.
+     *
+     * @param carModel the car model to set
+     */
     public void setCarModel(String carModel) {
         this.carModel = carModel;
     }

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingAlreadyCanceledException.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingAlreadyCanceledException.java
@@ -1,7 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking has already been canceled. */
 public class BookingAlreadyCanceledException extends RuntimeException {
 
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingAlreadyCanceledException(String bookingNumber) {
         super("Booking " + bookingNumber + " already canceled");
     }

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingCannotBeCanceledException.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingCannotBeCanceledException.java
@@ -1,7 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking cannot be canceled. */
 public class BookingCannotBeCanceledException extends RuntimeException {
 
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingCannotBeCanceledException(String bookingNumber) {
         super("Booking " + bookingNumber + " cannot be canceled");
     }

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingNotFoundException.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingNotFoundException.java
@@ -1,6 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking is not found. */
 public class BookingNotFoundException extends RuntimeException {
+
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingNotFoundException(String bookingNumber) {
         super("Booking " + bookingNumber + " not found");
     }

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingService.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingService.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+/** Car booking management service with tool methods for AI integration. */
 @ApplicationScoped
 public class BookingService {
 
@@ -16,6 +17,9 @@ public class BookingService {
 
     // Pseudo database
     private static final Map<String, Booking> BOOKINGS = new HashMap<>();
+
+    /** Creates a new booking service. */
+    public BookingService() {}
 
     static {
         // James Bond: hero customer!
@@ -78,6 +82,14 @@ public class BookingService {
         return booking;
     }
 
+    /**
+     * Retrieves booking details.
+     *
+     * @param bookingNumber the booking number
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the booking details
+     */
     @Tool("Get booking details given a booking number and customer name and surname")
     public Booking getBookingDetails(String bookingNumber, String name, String surname) {
         LOGGER.info(
@@ -85,6 +97,13 @@ public class BookingService {
         return checkBookingExists(bookingNumber, name, surname);
     }
 
+    /**
+     * Lists booking IDs for a customer.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the list of booking IDs
+     */
     @Tool("Get all booking ids for a customer given his name and surname")
     public List<String> getBookingsForCustomer(String name, String surname) {
         LOGGER.info("DEMO: Calling Tool-getBookingsForCustomer: " + name + " " + surname);
@@ -95,6 +114,11 @@ public class BookingService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Checks if a booking can be canceled per policy.
+     *
+     * @param booking the booking to check
+     */
     public void checkCancelPolicy(Booking booking) {
 
         // Reservations can be cancelled up to 7 days prior to the start of the booking
@@ -109,6 +133,14 @@ public class BookingService {
         }
     }
 
+    /**
+     * Cancels a booking.
+     *
+     * @param bookingNumber the booking number
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the canceled booking
+     */
     @Tool("Cancel a booking given its booking number and customer name and surname")
     public Booking cancelBooking(String bookingNumber, String name, String surname) {
         LOGGER.info("DEMO: Calling Tool-cancelBooking " + bookingNumber + " for customer: " + name + " " + surname);

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/CarBookingResource.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/CarBookingResource.java
@@ -11,6 +11,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 
+/** REST resource for car booking AI services. */
 @ApplicationScoped
 @Path("/car-booking")
 public class CarBookingResource {
@@ -21,6 +22,15 @@ public class CarBookingResource {
     @Inject
     private FraudAiService fraudService;
 
+    /** Creates a new car booking resource. */
+    public CarBookingResource() {}
+
+    /**
+     * Chats with the car booking assistant.
+     *
+     * @param question the question to ask
+     * @return the assistant's response
+     */
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/chat")
@@ -40,6 +50,13 @@ public class CarBookingResource {
         return answer;
     }
 
+    /**
+     * Detects fraud for a customer.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fraud detection response
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/fraud")

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
@@ -8,6 +8,7 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
+/** AI service for car booking customer support chat. */
 // @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
         chatModelName = "chat-model",
@@ -17,6 +18,12 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
         chatMemoryName = "chat-ai-service-memory")
 public interface ChatAiService {
 
+    /**
+     * Sends a question to the assistant and returns the response.
+     *
+     * @param question the question to ask
+     * @return the assistant's response
+     */
     @SystemMessage("""
             You are a customer support agent of a car rental company named 'Miles of Smiles'.
             Before providing information about booking or canceling a booking, you MUST always check:
@@ -44,6 +51,12 @@ public interface ChatAiService {
     // String chat(@V("question") @UserMessage String question);
     String chat(String question);
 
+    /**
+     * Fallback response when the chat service is unavailable.
+     *
+     * @param question the question that was asked
+     * @return the fallback response
+     */
     default String chatFallback(String question) {
         return String.format(
                 "Sorry, I am not able to answer your request %s at the moment. Please try again later.", question);

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Customer.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Customer.java
@@ -2,18 +2,21 @@ package dev.langchain4j.cdi.example.booking;
 
 import java.util.Objects;
 
+/** Customer information. */
 public class Customer {
     private String name;
     private String surname;
 
-    /** */
+    /** Creates a new customer. */
     public Customer() {
         super();
     }
 
     /**
-     * @param name
-     * @param surname
+     * Creates a new customer with the given name and surname.
+     *
+     * @param name the customer's first name
+     * @param surname the customer's surname
      */
     public Customer(String name, String surname) {
         super();
@@ -21,22 +24,38 @@ public class Customer {
         this.surname = surname;
     }
 
-    /** @return the name */
+    /**
+     * Returns the name.
+     *
+     * @return the name
+     */
     public String getName() {
         return name;
     }
 
-    /** @param name the name to set */
+    /**
+     * Sets the name.
+     *
+     * @param name the name to set
+     */
     public void setName(String name) {
         this.name = name;
     }
 
-    /** @return the surname */
+    /**
+     * Returns the surname.
+     *
+     * @return the surname
+     */
     public String getSurname() {
         return surname;
     }
 
-    /** @param surname the surname to set */
+    /**
+     * Sets the surname.
+     *
+     * @param surname the surname to set
+     */
     public void setSurname(String surname) {
         this.surname = surname;
     }

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/DocRagIngestor.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/DocRagIngestor.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.logging.Logger;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+/** Document RAG ingestor for loading car rental terms into the embedding store. */
 @ApplicationScoped
 public class DocRagIngestor {
 
@@ -38,10 +39,18 @@ public class DocRagIngestor {
     @ConfigProperty(name = "app.docs-for-rag.dir")
     private File docs;
 
+    /** Creates a new document RAG ingestor. */
+    public DocRagIngestor() {}
+
     private List<Document> loadDocs() {
         return loadDocuments(docs.getPath(), new TextDocumentParser());
     }
 
+    /**
+     * Ingests car rental terms document into the embedding store.
+     *
+     * @param pointless the CDI event object (unused)
+     */
     public void ingest(@Observes @Initialized(ApplicationScoped.class) Object pointless) {
 
         long start = System.currentTimeMillis();

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/DummyLLConfig.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/DummyLLConfig.java
@@ -7,10 +7,15 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/** File-based LLM configuration provider. */
 @SuppressWarnings("unused")
 public class DummyLLConfig extends LLMConfig {
     Properties properties = new Properties();
 
+    /** Creates a new configuration. */
+    public DummyLLConfig() {}
+
+    /** {@inheritDoc} */
     @Override
     public void init() {
         try (FileReader fileReader = new FileReader(System.getProperty("llmconfigfile"))) {
@@ -20,6 +25,7 @@ public class DummyLLConfig extends LLMConfig {
         }
     }
 
+    /** {@inheritDoc} */
     @Override
     public Set<String> getPropertyKeys() {
         return properties.keySet().stream()
@@ -28,6 +34,7 @@ public class DummyLLConfig extends LLMConfig {
                 .collect(Collectors.toSet());
     }
 
+    /** {@inheritDoc} */
     @Override
     public String getValue(String key) {
         return properties.getProperty(key);

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
@@ -9,6 +9,7 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
+/** AI service for booking fraud detection. */
 @RegisterAIService(
         contentRetrieverName = "docRagRetriever",
         chatMemoryName = "fraud-ai-service-memory",
@@ -16,6 +17,13 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
         tools = BookingService.class)
 public interface FraudAiService {
 
+    /**
+     * Detects fraud for a customer.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fraud detection response
+     */
     @SystemMessage("""
             You are a car booking fraud detection AI for Miles of Smiles.
             You have to detect customer fraud in bookings.
@@ -54,6 +62,13 @@ public interface FraudAiService {
     @Fallback(fallbackMethod = "fraudFallback")
     FraudResponse detectFraudForCustomer(@V("name") String name, @V("surname") String surname);
 
+    /**
+     * Fallback response when fraud detection is unavailable.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fallback response
+     */
     default FraudResponse fraudFallback(String name, String surname) {
         throw new RuntimeException("Sorry, I am not able to detect fraud for customer " + name + " " + surname
                 + " at the moment. Please try again later.");

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudResponse.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudResponse.java
@@ -3,48 +3,84 @@ package dev.langchain4j.cdi.example.booking;
 import java.util.List;
 
 // Warning: Java Record not supported by Google JSON (used by LangChain4J)
+/** Fraud detection response. */
 public class FraudResponse {
     private String customerName;
     private String customerSurname;
     private boolean fraudDetected;
     private List<String> bookingIds;
 
-    /** @return the customerName */
+    /** Creates a new fraud response. */
+    public FraudResponse() {}
+
+    /**
+     * Returns the customer name.
+     *
+     * @return the customer name
+     */
     public String getCustomerName() {
         return customerName;
     }
 
-    /** @param customerName the customerName to set */
+    /**
+     * Sets the customer name.
+     *
+     * @param customerName the customer name to set
+     */
     public void setCustomerName(String customerName) {
         this.customerName = customerName;
     }
 
-    /** @return the customerSurname */
+    /**
+     * Returns the customer surname.
+     *
+     * @return the customer surname
+     */
     public String getCustomerSurname() {
         return customerSurname;
     }
 
-    /** @param customerSurname the customerSurname to set */
+    /**
+     * Sets the customer surname.
+     *
+     * @param customerSurname the customer surname to set
+     */
     public void setCustomerSurname(String customerSurname) {
         this.customerSurname = customerSurname;
     }
 
-    /** @return the fraudDetected */
+    /**
+     * Returns whether fraud was detected.
+     *
+     * @return {@code true} if fraud was detected
+     */
     public boolean isFraudDetected() {
         return fraudDetected;
     }
 
-    /** @param fraudDetected the fraudDetected to set */
+    /**
+     * Sets whether fraud was detected.
+     *
+     * @param fraudDetected {@code true} if fraud was detected
+     */
     public void setFraudDetected(boolean fraudDetected) {
         this.fraudDetected = fraudDetected;
     }
 
-    /** @return the bookingIds */
+    /**
+     * Returns the booking IDs.
+     *
+     * @return the booking IDs
+     */
     public List<String> getBookingIds() {
         return bookingIds;
     }
 
-    /** @param bookingIds the bookingIds to set */
+    /**
+     * Sets the booking IDs.
+     *
+     * @param bookingIds the booking IDs to set
+     */
     public void setBookingIds(List<String> bookingIds) {
         this.bookingIds = bookingIds;
     }

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/JaxRSApp.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/JaxRSApp.java
@@ -3,5 +3,10 @@ package dev.langchain4j.cdi.example.booking;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 
+/** JAX-RS application configuration. */
 @ApplicationPath("/api")
-public class JaxRSApp extends Application {}
+public class JaxRSApp extends Application {
+
+    /** Creates a new JAX-RS application. */
+    public JaxRSApp() {}
+}

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/chat/Assistant.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/chat/Assistant.java
@@ -5,11 +5,19 @@ import dev.langchain4j.service.MemoryId;
 import dev.langchain4j.service.UserMessage;
 import jakarta.enterprise.context.ApplicationScoped;
 
+/** AI assistant interface for chat interactions with session memory. */
 @RegisterAIService(
         chatModelName = "chat-assistant",
         scope = ApplicationScoped.class,
         chatMemoryProviderName = "#default")
 interface Assistant {
 
+    /**
+     * Sends a message to the assistant within a session.
+     *
+     * @param sessionId the session identifier for memory
+     * @param userMessage the user message
+     * @return the assistant's response
+     */
     String chat(@MemoryId String sessionId, @UserMessage String userMessage);
 }

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/chat/ChatAgent.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/chat/ChatAgent.java
@@ -9,8 +9,12 @@ import jakarta.enterprise.inject.literal.NamedLiteral;
 import jakarta.enterprise.inject.spi.CDI;
 import jakarta.inject.Inject;
 
+/** CDI bean managing the chat agent and its memory provider. */
 @ApplicationScoped
 public class ChatAgent {
+
+    /** Creates a new ChatAgent. */
+    public ChatAgent() {}
 
     private static final String CHAT_MEMORY_CDI_NAME = "chat-ai-service-memory";
 
@@ -27,6 +31,11 @@ public class ChatAgent {
     @Inject
     private Assistant assistant = null;
 
+    /**
+     * Returns the assistant instance.
+     *
+     * @return the assistant
+     */
     public Assistant getAssistant() {
         if (assistant == null) {
             assistant = CDI.current().select(Assistant.class).get();
@@ -34,6 +43,13 @@ public class ChatAgent {
         return assistant;
     }
 
+    /**
+     * Sends a message to the assistant within a session.
+     *
+     * @param sessionId the session identifier
+     * @param message the user message
+     * @return the assistant's response
+     */
     public String chat(String sessionId, String message) {
         String reply = getAssistant().chat(sessionId, message).trim();
         int i = reply.lastIndexOf(message);

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/chat/ChatMessageEncoder.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/chat/ChatMessageEncoder.java
@@ -3,8 +3,13 @@ package dev.langchain4j.cdi.example.chat;
 import jakarta.websocket.EncodeException;
 import jakarta.websocket.Encoder;
 
+/** WebSocket encoder for chat messages. */
 public class ChatMessageEncoder implements Encoder.Text<String> {
 
+    /** Creates a new chat message encoder. */
+    public ChatMessageEncoder() {}
+
+    /** {@inheritDoc} */
     @Override
     public String encode(String message) throws EncodeException {
 

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/chat/ChatService.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/chat/ChatService.java
@@ -11,6 +11,7 @@ import jakarta.websocket.Session;
 import jakarta.websocket.server.ServerEndpoint;
 import java.util.logging.Logger;
 
+/** WebSocket endpoint for chat interactions. */
 @ApplicationScoped
 @ServerEndpoint(
         value = "/chat",
@@ -22,11 +23,25 @@ public class ChatService {
     @Inject
     ChatAgent agent = null;
 
+    /** Creates a new chat service. */
+    public ChatService() {}
+
+    /**
+     * Handles a new WebSocket connection.
+     *
+     * @param session the WebSocket session
+     */
     @OnOpen
     public void onOpen(Session session) {
         logger.info("Server connected to session: " + session.getId());
     }
 
+    /**
+     * Handles an incoming WebSocket message.
+     *
+     * @param message the message text
+     * @param session the WebSocket session
+     */
     @OnMessage
     public void onMessage(String message, Session session) {
 
@@ -47,11 +62,23 @@ public class ChatService {
         }
     }
 
+    /**
+     * Handles a WebSocket connection close.
+     *
+     * @param session the WebSocket session
+     * @param closeReason the close reason
+     */
     @OnClose
     public void onClose(Session session, CloseReason closeReason) {
         logger.info("Session " + session.getId() + " was closed with reason " + closeReason.getCloseCode());
     }
 
+    /**
+     * Handles a WebSocket error.
+     *
+     * @param session the WebSocket session
+     * @param throwable the error
+     */
     @OnError
     public void onError(Session session, Throwable throwable) {
         logger.info("WebSocket error for " + session.getId() + " " + throwable.getMessage());

--- a/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Booking.java
+++ b/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Booking.java
@@ -3,6 +3,7 @@ package dev.langchain4j.cdi.example.booking;
 import java.time.LocalDate;
 import java.util.Objects;
 
+/** Car booking details. */
 public class Booking {
 
     private String bookingNumber;
@@ -12,18 +13,20 @@ public class Booking {
     private boolean canceled = false;
     private String carModel;
 
-    /** */
+    /** Creates a new booking. */
     public Booking() {
         super();
     }
 
     /**
-     * @param bookingNumber
-     * @param start
-     * @param end
-     * @param customer
-     * @param canceled
-     * @param carModel
+     * Creates a new booking with the given details.
+     *
+     * @param bookingNumber the booking number
+     * @param start the start date
+     * @param end the end date
+     * @param customer the customer
+     * @param canceled whether the booking is canceled
+     * @param carModel the car model
      */
     public Booking(
             String bookingNumber,
@@ -41,62 +44,110 @@ public class Booking {
         this.carModel = carModel;
     }
 
-    /** @return the bookingNumber */
+    /**
+     * Returns the booking number.
+     *
+     * @return the booking number
+     */
     public String getBookingNumber() {
         return bookingNumber;
     }
 
-    /** @param bookingNumber the bookingNumber to set */
+    /**
+     * Sets the booking number.
+     *
+     * @param bookingNumber the booking number to set
+     */
     public void setBookingNumber(String bookingNumber) {
         this.bookingNumber = bookingNumber;
     }
 
-    /** @return the start */
+    /**
+     * Returns the start date.
+     *
+     * @return the start date
+     */
     public LocalDate getStart() {
         return start;
     }
 
-    /** @param start the start to set */
+    /**
+     * Sets the start date.
+     *
+     * @param start the start date to set
+     */
     public void setStart(LocalDate start) {
         this.start = start;
     }
 
-    /** @return the end */
+    /**
+     * Returns the end date.
+     *
+     * @return the end date
+     */
     public LocalDate getEnd() {
         return end;
     }
 
-    /** @param end the end to set */
+    /**
+     * Sets the end date.
+     *
+     * @param end the end date to set
+     */
     public void setEnd(LocalDate end) {
         this.end = end;
     }
 
-    /** @return the customer */
+    /**
+     * Returns the customer.
+     *
+     * @return the customer
+     */
     public Customer getCustomer() {
         return customer;
     }
 
-    /** @param customer the customer to set */
+    /**
+     * Sets the customer.
+     *
+     * @param customer the customer to set
+     */
     public void setCustomer(Customer customer) {
         this.customer = customer;
     }
 
-    /** @return the canceled */
+    /**
+     * Returns whether the booking is canceled.
+     *
+     * @return {@code true} if the booking is canceled
+     */
     public boolean isCanceled() {
         return canceled;
     }
 
-    /** @param canceled the canceled to set */
+    /**
+     * Sets whether the booking is canceled.
+     *
+     * @param canceled {@code true} if the booking is canceled
+     */
     public void setCanceled(boolean canceled) {
         this.canceled = canceled;
     }
 
-    /** @return the carModel */
+    /**
+     * Returns the car model.
+     *
+     * @return the car model
+     */
     public String getCarModel() {
         return carModel;
     }
 
-    /** @param carModel the carModel to set */
+    /**
+     * Sets the car model.
+     *
+     * @param carModel the car model to set
+     */
     public void setCarModel(String carModel) {
         this.carModel = carModel;
     }

--- a/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingAlreadyCanceledException.java
+++ b/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingAlreadyCanceledException.java
@@ -1,7 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking has already been canceled. */
 public class BookingAlreadyCanceledException extends RuntimeException {
 
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingAlreadyCanceledException(String bookingNumber) {
         super("Booking " + bookingNumber + " already canceled");
     }

--- a/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingCannotBeCanceledException.java
+++ b/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingCannotBeCanceledException.java
@@ -1,7 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking cannot be canceled. */
 public class BookingCannotBeCanceledException extends RuntimeException {
 
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingCannotBeCanceledException(String bookingNumber) {
         super("Booking " + bookingNumber + " cannot be canceled");
     }

--- a/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingNotFoundException.java
+++ b/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingNotFoundException.java
@@ -1,6 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking is not found. */
 public class BookingNotFoundException extends RuntimeException {
+
+    /**
+     * Creates a new exception for the given booking number.
+     *
+     * @param bookingNumber the booking number
+     */
     public BookingNotFoundException(String bookingNumber) {
         super("Booking " + bookingNumber + " not found");
     }

--- a/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingService.java
+++ b/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingService.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+/** Car booking management service with tool methods for AI integration. */
 @ApplicationScoped
 public class BookingService {
 
@@ -16,6 +17,9 @@ public class BookingService {
 
     // Pseudo database
     private static final Map<String, Booking> BOOKINGS = new HashMap<>();
+
+    /** Creates a new booking service. */
+    public BookingService() {}
 
     static {
         // James Bond: hero customer!
@@ -78,6 +82,14 @@ public class BookingService {
         return booking;
     }
 
+    /**
+     * Retrieves booking details.
+     *
+     * @param bookingNumber the booking number
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the booking details
+     */
     @Tool("Get booking details given a booking number and customer name and surname")
     public Booking getBookingDetails(String bookingNumber, String name, String surname) {
         LOGGER.info(
@@ -85,6 +97,13 @@ public class BookingService {
         return checkBookingExists(bookingNumber, name, surname);
     }
 
+    /**
+     * Lists booking IDs for a customer.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the list of booking IDs
+     */
     @Tool("Get all booking ids for a customer given his name and surname")
     public List<String> getBookingsForCustomer(String name, String surname) {
         LOGGER.info("DEMO: Calling Tool-getBookingsForCustomer: " + name + " " + surname);
@@ -95,6 +114,11 @@ public class BookingService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Checks if a booking can be canceled per policy.
+     *
+     * @param booking the booking to check
+     */
     public void checkCancelPolicy(Booking booking) {
 
         // Reservations can be cancelled up to 7 days prior to the start of the booking
@@ -109,6 +133,14 @@ public class BookingService {
         }
     }
 
+    /**
+     * Cancels a booking.
+     *
+     * @param bookingNumber the booking number
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the canceled booking
+     */
     @Tool("Cancel a booking given its booking number and customer name and surname")
     public Booking cancelBooking(String bookingNumber, String name, String surname) {
         LOGGER.info("DEMO: Calling Tool-cancelBooking " + bookingNumber + " for customer: " + name + " " + surname);

--- a/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/CarBookingResource.java
+++ b/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/CarBookingResource.java
@@ -12,6 +12,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 
+/** REST resource for car booking AI services. */
 @ApplicationScoped
 @Path("/car-booking")
 public class CarBookingResource {
@@ -22,6 +23,15 @@ public class CarBookingResource {
     @Inject
     private FraudAiService fraudService;
 
+    /** Creates a new car booking resource. */
+    public CarBookingResource() {}
+
+    /**
+     * Chats with the car booking assistant.
+     *
+     * @param question the question to ask
+     * @return the assistant's response
+     */
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/chat")
@@ -51,6 +61,13 @@ public class CarBookingResource {
         return answer;
     }
 
+    /**
+     * Detects fraud for a customer.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fraud detection response
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/fraud")

--- a/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
+++ b/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
@@ -7,6 +7,7 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
+/** AI service for car booking customer support chat. */
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
         tools = BookingService.class,
@@ -14,6 +15,12 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
         chatMemoryName = "chat-ai-service-memory")
 public interface ChatAiService {
 
+    /**
+     * Sends a question to the assistant and returns the response.
+     *
+     * @param question the question to ask
+     * @return the assistant's response
+     */
     @SystemMessage("""
             You are a customer support agent of a car rental company named 'Miles of Smiles'.
             Before providing information about booking or canceling a booking, you MUST always check:
@@ -41,6 +48,12 @@ public interface ChatAiService {
     // String chat(@V("question") @UserMessage String question);
     String chat(String question);
 
+    /**
+     * Fallback response when the chat service is unavailable.
+     *
+     * @param question the question that was asked
+     * @return the fallback response
+     */
     default String chatFallback(String question) {
         return String.format(
                 "Sorry, I am not able to answer your request %s at the moment. Please try again later.", question);

--- a/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Customer.java
+++ b/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Customer.java
@@ -2,18 +2,21 @@ package dev.langchain4j.cdi.example.booking;
 
 import java.util.Objects;
 
+/** Customer information. */
 public class Customer {
     private String name;
     private String surname;
 
-    /** */
+    /** Creates a new customer. */
     public Customer() {
         super();
     }
 
     /**
-     * @param name
-     * @param surname
+     * Creates a new customer with the given name and surname.
+     *
+     * @param name the customer's first name
+     * @param surname the customer's surname
      */
     public Customer(String name, String surname) {
         super();
@@ -21,22 +24,38 @@ public class Customer {
         this.surname = surname;
     }
 
-    /** @return the name */
+    /**
+     * Returns the name.
+     *
+     * @return the name
+     */
     public String getName() {
         return name;
     }
 
-    /** @param name the name to set */
+    /**
+     * Sets the name.
+     *
+     * @param name the name to set
+     */
     public void setName(String name) {
         this.name = name;
     }
 
-    /** @return the surname */
+    /**
+     * Returns the surname.
+     *
+     * @return the surname
+     */
     public String getSurname() {
         return surname;
     }
 
-    /** @param surname the surname to set */
+    /**
+     * Sets the surname.
+     *
+     * @param surname the surname to set
+     */
     public void setSurname(String surname) {
         this.surname = surname;
     }

--- a/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/DocRagIngestor.java
+++ b/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/DocRagIngestor.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.logging.Logger;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+/** Document RAG ingestor for loading car rental terms into the embedding store. */
 @ApplicationScoped
 public class DocRagIngestor {
 
@@ -40,10 +41,18 @@ public class DocRagIngestor {
     @ConfigProperty(name = "app.docs-for-rag.dir")
     private File docs;
 
+    /** Creates a new document RAG ingestor. */
+    public DocRagIngestor() {}
+
     private List<Document> loadDocs() {
         return loadDocuments(docs.getPath(), new TextDocumentParser());
     }
 
+    /**
+     * Ingests car rental terms document into the embedding store.
+     *
+     * @param pointless the CDI event object (unused)
+     */
     public void ingest(@Observes @Initialized(ApplicationScoped.class) Object pointless) {
 
         long start = System.currentTimeMillis();

--- a/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
+++ b/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
@@ -9,6 +9,7 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
+/** AI service for booking fraud detection. */
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
         contentRetrieverName = "docRagRetriever",
@@ -16,6 +17,13 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
         tools = BookingService.class)
 public interface FraudAiService {
 
+    /**
+     * Detects fraud for a customer.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fraud detection response
+     */
     @SystemMessage("""
             You are a car booking fraud detection AI for Miles of Smiles.
             You have to detect customer fraud in bookings.
@@ -54,6 +62,13 @@ public interface FraudAiService {
     @Fallback(fallbackMethod = "fraudFallback")
     FraudResponse detectFraudForCustomer(@V("name") String name, @V("surname") String surname);
 
+    /**
+     * Fallback response when fraud detection is unavailable.
+     *
+     * @param name the customer name
+     * @param surname the customer surname
+     * @return the fallback response
+     */
     default FraudResponse fraudFallback(String name, String surname) {
         throw new RuntimeException("Sorry, I am not able to detect fraud for customer " + name + " " + surname
                 + " at the moment. Please try again later.");

--- a/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudResponse.java
+++ b/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudResponse.java
@@ -3,48 +3,84 @@ package dev.langchain4j.cdi.example.booking;
 import java.util.List;
 
 // Warning: Java Record not supported by Google JSON (used by LangChain4J)
+/** Fraud detection response. */
 public class FraudResponse {
     private String customerName;
     private String customerSurname;
     private boolean fraudDetected;
     private List<String> bookingIds;
 
-    /** @return the customerName */
+    /** Creates a new fraud response. */
+    public FraudResponse() {}
+
+    /**
+     * Returns the customer name.
+     *
+     * @return the customer name
+     */
     public String getCustomerName() {
         return customerName;
     }
 
-    /** @param customerName the customerName to set */
+    /**
+     * Sets the customer name.
+     *
+     * @param customerName the customer name to set
+     */
     public void setCustomerName(String customerName) {
         this.customerName = customerName;
     }
 
-    /** @return the customerSurname */
+    /**
+     * Returns the customer surname.
+     *
+     * @return the customer surname
+     */
     public String getCustomerSurname() {
         return customerSurname;
     }
 
-    /** @param customerSurname the customerSurname to set */
+    /**
+     * Sets the customer surname.
+     *
+     * @param customerSurname the customer surname to set
+     */
     public void setCustomerSurname(String customerSurname) {
         this.customerSurname = customerSurname;
     }
 
-    /** @return the fraudDetected */
+    /**
+     * Returns whether fraud was detected.
+     *
+     * @return {@code true} if fraud was detected
+     */
     public boolean isFraudDetected() {
         return fraudDetected;
     }
 
-    /** @param fraudDetected the fraudDetected to set */
+    /**
+     * Sets whether fraud was detected.
+     *
+     * @param fraudDetected {@code true} if fraud was detected
+     */
     public void setFraudDetected(boolean fraudDetected) {
         this.fraudDetected = fraudDetected;
     }
 
-    /** @return the bookingIds */
+    /**
+     * Returns the booking IDs.
+     *
+     * @return the booking IDs
+     */
     public List<String> getBookingIds() {
         return bookingIds;
     }
 
-    /** @param bookingIds the bookingIds to set */
+    /**
+     * Sets the booking IDs.
+     *
+     * @param bookingIds the booking IDs to set
+     */
     public void setBookingIds(List<String> bookingIds) {
         this.bookingIds = bookingIds;
     }

--- a/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Booking.java
+++ b/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Booking.java
@@ -13,8 +13,19 @@ public class Booking {
     private boolean canceled = false;
     private String carModel;
 
+    /** Creates a new empty booking. */
     public Booking() {}
 
+    /**
+     * Creates a new booking with the specified details.
+     *
+     * @param bookingNumber the unique booking identifier
+     * @param start the start date of the rental period
+     * @param end the end date of the rental period
+     * @param customer the customer who made the booking
+     * @param canceled whether the booking is canceled
+     * @param carModel the model of the rented car
+     */
     public Booking(
             String bookingNumber,
             LocalDate start,
@@ -30,50 +41,110 @@ public class Booking {
         this.carModel = carModel;
     }
 
+    /**
+     * Returns the booking number.
+     *
+     * @return the unique booking identifier
+     */
     public String getBookingNumber() {
         return bookingNumber;
     }
 
+    /**
+     * Sets the booking number.
+     *
+     * @param bookingNumber the unique booking identifier
+     */
     public void setBookingNumber(String bookingNumber) {
         this.bookingNumber = bookingNumber;
     }
 
+    /**
+     * Returns the start date of the rental period.
+     *
+     * @return the start date
+     */
     public LocalDate getStart() {
         return start;
     }
 
+    /**
+     * Sets the start date of the rental period.
+     *
+     * @param start the start date
+     */
     public void setStart(LocalDate start) {
         this.start = start;
     }
 
+    /**
+     * Returns the end date of the rental period.
+     *
+     * @return the end date
+     */
     public LocalDate getEnd() {
         return end;
     }
 
+    /**
+     * Sets the end date of the rental period.
+     *
+     * @param end the end date
+     */
     public void setEnd(LocalDate end) {
         this.end = end;
     }
 
+    /**
+     * Returns the customer who made the booking.
+     *
+     * @return the customer
+     */
     public Customer getCustomer() {
         return customer;
     }
 
+    /**
+     * Sets the customer who made the booking.
+     *
+     * @param customer the customer
+     */
     public void setCustomer(Customer customer) {
         this.customer = customer;
     }
 
+    /**
+     * Returns whether the booking is canceled.
+     *
+     * @return {@code true} if canceled, {@code false} otherwise
+     */
     public boolean isCanceled() {
         return canceled;
     }
 
+    /**
+     * Sets the canceled status of the booking.
+     *
+     * @param canceled {@code true} to mark as canceled
+     */
     public void setCanceled(boolean canceled) {
         this.canceled = canceled;
     }
 
+    /**
+     * Returns the car model.
+     *
+     * @return the car model name
+     */
     public String getCarModel() {
         return carModel;
     }
 
+    /**
+     * Sets the car model.
+     *
+     * @param carModel the car model name
+     */
     public void setCarModel(String carModel) {
         this.carModel = carModel;
     }

--- a/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingAlreadyCanceledException.java
+++ b/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingAlreadyCanceledException.java
@@ -1,7 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when attempting to cancel a booking that has already been canceled. */
 public class BookingAlreadyCanceledException extends RuntimeException {
 
+    /**
+     * Creates a new exception for an already canceled booking.
+     *
+     * @param bookingNumber the booking number that was already canceled
+     */
     public BookingAlreadyCanceledException(String bookingNumber) {
         super("Booking " + bookingNumber + " already canceled");
     }

--- a/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingCannotBeCanceledException.java
+++ b/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingCannotBeCanceledException.java
@@ -1,7 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking cannot be canceled due to policy restrictions. */
 public class BookingCannotBeCanceledException extends RuntimeException {
 
+    /**
+     * Creates a new exception for a booking that cannot be canceled.
+     *
+     * @param bookingNumber the booking number that cannot be canceled
+     */
     public BookingCannotBeCanceledException(String bookingNumber) {
         super("Booking " + bookingNumber + " cannot be canceled");
     }

--- a/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingNotFoundException.java
+++ b/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingNotFoundException.java
@@ -1,6 +1,13 @@
 package dev.langchain4j.cdi.example.booking;
 
+/** Thrown when a booking cannot be found by its number. */
 public class BookingNotFoundException extends RuntimeException {
+
+    /**
+     * Creates a new exception for a missing booking.
+     *
+     * @param bookingNumber the booking number that was not found
+     */
     public BookingNotFoundException(String bookingNumber) {
         super("Booking " + bookingNumber + " not found");
     }

--- a/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingService.java
+++ b/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/BookingService.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+/** Car booking management service with tool methods for AI integration. */
 @ApplicationScoped
 public class BookingService {
 
@@ -16,6 +17,9 @@ public class BookingService {
 
     // Pseudo database
     private static final Map<String, Booking> BOOKINGS = new HashMap<>();
+
+    /** Creates a new booking service. */
+    public BookingService() {}
 
     static {
         // James Bond: hero customer!
@@ -78,6 +82,14 @@ public class BookingService {
         return booking;
     }
 
+    /**
+     * Retrieves booking details.
+     *
+     * @param bookingNumber the booking number to look up
+     * @param name the customer's first name
+     * @param surname the customer's surname
+     * @return the booking details
+     */
     @Tool("Get booking details given a booking number and customer name and surname")
     public Booking getBookingDetails(String bookingNumber, String name, String surname) {
         LOGGER.info(
@@ -85,6 +97,13 @@ public class BookingService {
         return checkBookingExists(bookingNumber, name, surname);
     }
 
+    /**
+     * Lists booking IDs for a customer.
+     *
+     * @param name the customer's first name
+     * @param surname the customer's surname
+     * @return the list of booking identifiers for the customer
+     */
     @Tool("Get all booking ids for a customer given his name and surname")
     public List<String> getBookingsForCustomer(String name, String surname) {
         LOGGER.info("DEMO: Calling Tool-getBookingsForCustomer: " + name + " " + surname);
@@ -95,6 +114,11 @@ public class BookingService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Checks if a booking can be canceled per policy.
+     *
+     * @param booking the booking to check against cancellation policy
+     */
     public void checkCancelPolicy(Booking booking) {
         // Reservations can be canceled up to 7 days prior to the start of the booking period
         if (LocalDate.now().plusDays(7).isAfter(booking.getStart())) {
@@ -107,6 +131,14 @@ public class BookingService {
         }
     }
 
+    /**
+     * Cancels a booking.
+     *
+     * @param bookingNumber the booking number to cancel
+     * @param name the customer's first name
+     * @param surname the customer's surname
+     * @return the canceled booking
+     */
     @Tool("Cancel a booking given its booking number and customer name and surname")
     public Booking cancelBooking(String bookingNumber, String name, String surname) {
         LOGGER.info("DEMO: Calling Tool-cancelBooking " + bookingNumber + " for customer: " + name + " " + surname);

--- a/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/CarBookingApplication.java
+++ b/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/CarBookingApplication.java
@@ -3,5 +3,10 @@ package dev.langchain4j.cdi.example.booking;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 
+/** JAX-RS application configuration for the car booking service. */
 @ApplicationPath("/")
-public class CarBookingApplication extends Application {}
+public class CarBookingApplication extends Application {
+
+    /** Creates a new car booking application. */
+    public CarBookingApplication() {}
+}

--- a/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/CarBookingResource.java
+++ b/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/CarBookingResource.java
@@ -15,6 +15,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 
+/** REST resource for car booking AI services. */
 @ApplicationScoped
 @Path("/car-booking")
 public class CarBookingResource {
@@ -26,6 +27,15 @@ public class CarBookingResource {
     @Inject
     private FraudAiService fraudService;
 
+    /** Creates a new car booking resource. */
+    public CarBookingResource() {}
+
+    /**
+     * Chats with the car booking assistant.
+     *
+     * @param question the question to ask the assistant
+     * @return the assistant's response
+     */
     @GET
     @Produces(MediaType.TEXT_PLAIN)
     @Path("/chat")
@@ -55,6 +65,13 @@ public class CarBookingResource {
         }
     }
 
+    /**
+     * Detects fraud for a customer.
+     *
+     * @param name the customer's first name
+     * @param surname the customer's surname
+     * @return the fraud detection response
+     */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/fraud")

--- a/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
+++ b/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
@@ -7,6 +7,7 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
+/** AI service for car booking customer support chat. */
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
         tools = BookingService.class,
@@ -14,6 +15,12 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
         chatMemoryName = "chat-ai-service-memory")
 public interface ChatAiService {
 
+    /**
+     * Sends a question to the assistant and returns the response.
+     *
+     * @param question the user's question
+     * @return the assistant's response
+     */
     @SystemMessage("""
             You are a customer support agent of a car rental company named 'Miles of Smiles'.
             Before providing information about booking or canceling a booking, you MUST always check:
@@ -40,6 +47,12 @@ public interface ChatAiService {
             })
     String chat(String question);
 
+    /**
+     * Fallback response when the chat service is unavailable.
+     *
+     * @param question the user's question
+     * @return an error message asking the user to try again later
+     */
     default String chatFallback(String question) {
         return String.format(
                 "Sorry, I am not able to answer your request %s at the moment. Please try again later.", question);

--- a/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Customer.java
+++ b/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/Customer.java
@@ -7,25 +7,52 @@ public class Customer {
     private String name;
     private String surname;
 
+    /** Creates a new empty customer. */
     public Customer() {}
 
+    /**
+     * Creates a new customer with the specified name and surname.
+     *
+     * @param name the customer's first name
+     * @param surname the customer's surname
+     */
     public Customer(String name, String surname) {
         this.name = name;
         this.surname = surname;
     }
 
+    /**
+     * Returns the customer's first name.
+     *
+     * @return the first name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Sets the customer's first name.
+     *
+     * @param name the first name
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * Returns the customer's surname.
+     *
+     * @return the surname
+     */
     public String getSurname() {
         return surname;
     }
 
+    /**
+     * Sets the customer's surname.
+     *
+     * @param surname the surname
+     */
     public void setSurname(String surname) {
         this.surname = surname;
     }

--- a/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/DocRagIngestor.java
+++ b/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/DocRagIngestor.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.logging.Logger;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+/** Document RAG ingestor for loading car rental terms into the embedding store. */
 @ApplicationScoped
 public class DocRagIngestor {
 
@@ -33,10 +34,18 @@ public class DocRagIngestor {
     @ConfigProperty(name = "app.docs-for-rag.dir")
     private File docs;
 
+    /** Creates a new document RAG ingestor. */
+    public DocRagIngestor() {}
+
     private List<Document> loadDocs() {
         return loadDocuments(docs.getPath(), new TextDocumentParser());
     }
 
+    /**
+     * Ingests car rental terms document into the embedding store.
+     *
+     * @param pointless the CDI initialization event object (unused)
+     */
     public void ingest(@Observes @Initialized(ApplicationScoped.class) Object pointless) {
 
         long start = System.currentTimeMillis();

--- a/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/EmbeddingsProducers.java
+++ b/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/EmbeddingsProducers.java
@@ -7,15 +7,29 @@ import dev.langchain4j.store.embedding.inmemory.InMemoryEmbeddingStore;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 
+/** CDI producer for embedding model and embedding store beans. */
 @ApplicationScoped
 public class EmbeddingsProducers {
 
+    /** Creates a new embeddings producer. */
+    public EmbeddingsProducers() {}
+
+    /**
+     * Produces the embedding model bean.
+     *
+     * @return the all-MiniLM-L6-v2 embedding model
+     */
     @Produces
     @ApplicationScoped
     public EmbeddingModel embeddingModel() {
         return new AllMiniLmL6V2EmbeddingModel();
     }
 
+    /**
+     * Produces the in-memory embedding store bean.
+     *
+     * @return a new in-memory embedding store
+     */
     @Produces
     @ApplicationScoped
     public InMemoryEmbeddingStore<TextSegment> embeddingStore() {

--- a/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
+++ b/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
@@ -9,6 +9,7 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
+/** AI service for booking fraud detection. */
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
         tools = BookingService.class,
@@ -16,6 +17,13 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
         chatMemoryName = "fraud-ai-service-memory")
 public interface FraudAiService {
 
+    /**
+     * Detects fraud for a customer by analyzing their bookings for overlaps.
+     *
+     * @param name the customer's first name
+     * @param surname the customer's surname
+     * @return the fraud detection response
+     */
     @SystemMessage("""
             You are a car booking fraud detection AI for Miles of Smiles.
             You have to detect customer fraud in bookings.
@@ -54,6 +62,13 @@ public interface FraudAiService {
     @Fallback(fallbackMethod = "fraudFallback")
     FraudResponse detectFraudForCustomer(@V("name") String name, @V("surname") String surname);
 
+    /**
+     * Fallback response when fraud detection is unavailable.
+     *
+     * @param name the customer's first name
+     * @param surname the customer's surname
+     * @return never returns normally; always throws
+     */
     default FraudResponse fraudFallback(String name, String surname) {
         throw new RuntimeException("Sorry, I am not able to detect fraud for customer " + name + " " + surname
                 + " at the moment. Please try again later.");

--- a/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudResponse.java
+++ b/examples/wildfly-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudResponse.java
@@ -2,7 +2,7 @@ package dev.langchain4j.cdi.example.booking;
 
 import java.util.List;
 
-// Not a record because Google JSON (used by LangChain4J) does not support records.
+/** Response from the fraud detection AI service. Not a record because Google JSON does not support records. */
 public class FraudResponse {
     private String customerName;
     private String customerSurname;
@@ -10,42 +10,95 @@ public class FraudResponse {
     private List<String> bookingIds;
     private String fraudExplanation;
 
+    /** Creates a new empty fraud response. */
+    public FraudResponse() {}
+
+    /**
+     * Returns the customer's first name.
+     *
+     * @return the customer name
+     */
     public String getCustomerName() {
         return customerName;
     }
 
+    /**
+     * Sets the customer's first name.
+     *
+     * @param customerName the customer name
+     */
     public void setCustomerName(String customerName) {
         this.customerName = customerName;
     }
 
+    /**
+     * Returns the customer's surname.
+     *
+     * @return the customer surname
+     */
     public String getCustomerSurname() {
         return customerSurname;
     }
 
+    /**
+     * Sets the customer's surname.
+     *
+     * @param customerSurname the customer surname
+     */
     public void setCustomerSurname(String customerSurname) {
         this.customerSurname = customerSurname;
     }
 
+    /**
+     * Returns whether fraud was detected.
+     *
+     * @return {@code true} if fraud was detected, {@code false} otherwise
+     */
     public boolean isFraudDetected() {
         return fraudDetected;
     }
 
+    /**
+     * Sets whether fraud was detected.
+     *
+     * @param fraudDetected {@code true} if fraud was detected
+     */
     public void setFraudDetected(boolean fraudDetected) {
         this.fraudDetected = fraudDetected;
     }
 
+    /**
+     * Returns the list of overlapping booking IDs.
+     *
+     * @return the booking identifiers involved in fraud
+     */
     public List<String> getBookingIds() {
         return bookingIds;
     }
 
+    /**
+     * Sets the list of overlapping booking IDs.
+     *
+     * @param bookingIds the booking identifiers involved in fraud
+     */
     public void setBookingIds(List<String> bookingIds) {
         this.bookingIds = bookingIds;
     }
 
+    /**
+     * Returns the fraud explanation.
+     *
+     * @return the explanation of the detected fraud
+     */
     public String getFraudExplanation() {
         return fraudExplanation;
     }
 
+    /**
+     * Sets the fraud explanation.
+     *
+     * @param fraudExplanation the explanation of the detected fraud
+     */
     public void setFraudExplanation(String fraudExplanation) {
         this.fraudExplanation = fraudExplanation;
     }

--- a/langchain4j-cdi-a2a/src/main/java/dev/langchain4j/cdi/agent/a2a/DefaultA2AAgentBuilder.java
+++ b/langchain4j-cdi-a2a/src/main/java/dev/langchain4j/cdi/agent/a2a/DefaultA2AAgentBuilder.java
@@ -7,7 +7,14 @@ import dev.langchain4j.cdi.agent.spi.A2AAgentBuilder;
 import dev.langchain4j.cdi.aiservice.CdiLookupHelper;
 import jakarta.enterprise.inject.Instance;
 
+/**
+ * Default {@link A2AAgentBuilder} implementation that creates A2A agent proxies using the LangChain4j
+ * {@link AgenticServices#a2aBuilder(String, Class)} API. Discovered via {@link java.util.ServiceLoader}.
+ */
 public class DefaultA2AAgentBuilder implements A2AAgentBuilder {
+
+    /** Creates a new {@code DefaultA2AAgentBuilder}. */
+    public DefaultA2AAgentBuilder() {}
 
     @Override
     public <X> X build(

--- a/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/aiservice/AIAgentCreator.java
+++ b/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/aiservice/AIAgentCreator.java
@@ -5,7 +5,14 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.build.compatible.spi.Parameters;
 import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
 
+/**
+ * Synthetic bean creator that instantiates agent proxies at runtime using the interface class stored during build-time
+ * synthesis.
+ */
 public class AIAgentCreator implements SyntheticBeanCreator<Object> {
+
+    /** Creates a new {@code AIAgentCreator}. */
+    public AIAgentCreator() {}
 
     @Override
     public Object create(Instance<Object> lookup, Parameters params) {

--- a/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/aiservice/AIServiceCreator.java
+++ b/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/aiservice/AIServiceCreator.java
@@ -4,7 +4,14 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.build.compatible.spi.Parameters;
 import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
 
+/**
+ * Synthetic bean creator that instantiates AI service proxies at runtime using the interface class stored during
+ * build-time synthesis.
+ */
 public class AIServiceCreator implements SyntheticBeanCreator<Object> {
+
+    /** Creates a new {@code AIServiceCreator}. */
+    public AIServiceCreator() {}
 
     @Override
     public Object create(Instance<Object> lookup, Parameters params) {

--- a/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/aiservice/Langchain4JAIServiceBuildCompatibleExtension.java
+++ b/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/aiservice/Langchain4JAIServiceBuildCompatibleExtension.java
@@ -37,22 +37,49 @@ import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+/**
+ * Build-compatible CDI extension that discovers {@code @RegisterAIService} and agent-annotated interfaces at build time
+ * and registers synthetic beans for them.
+ */
 public class Langchain4JAIServiceBuildCompatibleExtension implements BuildCompatibleExtension {
     private static final Logger LOGGER = Logger.getLogger(Langchain4JAIServiceBuildCompatibleExtension.class.getName());
     private static final Set<Class<?>> detectedAIServicesDeclaredInterfaces = new HashSet<>();
     private static final Set<Class<?>> detectedAgentDeclaredInterfaces = new HashSet<>();
     private static final Set<String> detectedTools = new HashSet<>();
+
+    /** Synthetic bean parameter key for the AI service interface class. */
     public static final String PARAM_INTERFACE_CLASS = "interfaceClass";
+
+    /** Synthetic bean parameter key for the agent interface class. */
     public static final String PARAM_AGENT_INTERFACE_CLASS = "agentInterfaceClass";
 
+    /** Creates a new {@code Langchain4JAIServiceBuildCompatibleExtension}. */
+    public Langchain4JAIServiceBuildCompatibleExtension() {}
+
+    /**
+     * Returns the set of detected AI service interface classes.
+     *
+     * @return the detected AI service interfaces
+     */
     public static Set<Class<?>> getDetectedAIServicesDeclaredInterfaces() {
         return detectedAIServicesDeclaredInterfaces;
     }
 
+    /**
+     * Returns the set of detected agent interface classes.
+     *
+     * @return the detected agent interfaces
+     */
     public static Set<Class<?>> getDetectedAgentDeclaredInterfaces() {
         return detectedAgentDeclaredInterfaces;
     }
 
+    /**
+     * Adds a {@link Named} qualifier to detected tool classes so they are not removed by Quarkus bean pruning.
+     *
+     * @param classConfig the class configuration to enhance
+     * @throws ClassNotFoundException if the tool class cannot be loaded
+     */
     @SuppressWarnings("unused")
     @Enhancement(types = Object.class, withSubtypes = true)
     @Priority(20)
@@ -67,6 +94,12 @@ public class Langchain4JAIServiceBuildCompatibleExtension implements BuildCompat
         }
     }
 
+    /**
+     * Detects classes annotated with {@link RegisterAIService} and registers them for synthesis.
+     *
+     * @param classConfig the class configuration to inspect
+     * @throws ClassNotFoundException if the class cannot be loaded
+     */
     @SuppressWarnings("unused")
     @Enhancement(types = Object.class, withAnnotations = RegisterAIService.class, withSubtypes = true)
     @Priority(10)
@@ -75,6 +108,13 @@ public class Langchain4JAIServiceBuildCompatibleExtension implements BuildCompat
         registerAIService(classInfo);
     }
 
+    /**
+     * Detects fields whose type is annotated with {@link RegisterAIService} or an agent annotation and registers the
+     * corresponding interface for synthesis.
+     *
+     * @param config the field configuration to inspect
+     * @throws ClassNotFoundException if the field type class cannot be loaded
+     */
     @Enhancement(types = Object.class, withSubtypes = true)
     @Priority(30)
     public void detectRegisterAIService(FieldConfig config) throws ClassNotFoundException {
@@ -96,6 +136,12 @@ public class Langchain4JAIServiceBuildCompatibleExtension implements BuildCompat
         }
     }
 
+    /**
+     * Detects classes annotated with any of the 11 agent topology annotations and registers them for synthesis.
+     *
+     * @param classConfig the class configuration to inspect
+     * @throws ClassNotFoundException if the class cannot be loaded
+     */
     @SuppressWarnings("unused")
     @Enhancement(
             types = Object.class,
@@ -171,6 +217,12 @@ public class Langchain4JAIServiceBuildCompatibleExtension implements BuildCompat
         return Thread.currentThread().getContextClassLoader().loadClass(className);
     }
 
+    /**
+     * Synthesizes CDI beans for all detected AI service and agent interfaces.
+     *
+     * @param syntheticComponents the synthetic components builder provided by the CDI container
+     * @throws ClassNotFoundException if a required class cannot be loaded
+     */
     @SuppressWarnings({"unused", "unchecked"})
     @Synthesis
     public void synthesisAllRegisterAIServices(SyntheticComponents syntheticComponents) throws ClassNotFoundException {

--- a/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/plugin/LLMPluginCreator.java
+++ b/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/plugin/LLMPluginCreator.java
@@ -5,7 +5,12 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.build.compatible.spi.Parameters;
 import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
 
+/** Synthetic bean creator that instantiates LLM plugin beans from their configuration parameters. */
 public class LLMPluginCreator implements SyntheticBeanCreator<Object> {
+
+    /** Creates a new LLMPluginCreator. */
+    public LLMPluginCreator() {}
+
     @Override
     public Object create(Instance<Object> lookup, Parameters params) {
         return CommonLLMPluginCreator.create(

--- a/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/plugin/LangChain4JPluginsBuildCompatibleExtension.java
+++ b/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/plugin/LangChain4JPluginsBuildCompatibleExtension.java
@@ -10,14 +10,32 @@ import jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents;
 import jakarta.enterprise.inject.literal.NamedLiteral;
 import java.util.logging.Logger;
 
+/** Build-compatible CDI extension that registers LangChain4j plugin beans as synthetic beans at build time. */
 public class LangChain4JPluginsBuildCompatibleExtension implements BuildCompatibleExtension {
+
+    /** Logger for this extension. */
     public static final Logger LOGGER = Logger.getLogger(LangChain4JPluginsBuildCompatibleExtension.class.getName());
+
+    /** Synthetic bean parameter key for the bean name. */
     public static final String PARAM_BEANNAME = "beanName";
+
+    /** Synthetic bean parameter key for the target class. */
     public static final String PARAM_TARGET_CLASS = "targetClass";
+
+    /** Synthetic bean parameter key for the builder class. */
     public static final String PARAM_BUILDER_CLASS = "builderClass";
 
     private LLMConfig llmConfig;
 
+    /** Creates a new LangChain4JPluginsBuildCompatibleExtension. */
+    public LangChain4JPluginsBuildCompatibleExtension() {}
+
+    /**
+     * Synthesis callback that creates synthetic CDI beans for all configured LLM plugins.
+     *
+     * @param syntheticComponents the synthetic components registry
+     * @throws ClassNotFoundException if a configured plugin class cannot be found
+     */
     @SuppressWarnings({"unused", "unchecked"})
     @Synthesis
     public void createSynthetics(SyntheticComponents syntheticComponents) throws ClassNotFoundException {

--- a/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/spi/AISyntheticBeanCreatorClassFactory.java
+++ b/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/spi/AISyntheticBeanCreatorClassFactory.java
@@ -6,8 +6,17 @@ package dev.langchain4j.cdi.spi;
 
 import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
 
+/**
+ * SPI for providing a custom {@link SyntheticBeanCreator} class used to instantiate LLM plugin beans. Implementations
+ * are discovered via {@link java.util.ServiceLoader} and the highest-priority factory is selected.
+ */
 public interface AISyntheticBeanCreatorClassFactory extends Comparable<AISyntheticBeanCreatorClassFactory> {
 
+    /**
+     * Returns the {@link SyntheticBeanCreator} class to use for creating LLM plugin beans.
+     *
+     * @return the synthetic bean creator class
+     */
     Class<? extends SyntheticBeanCreator<Object>> getSyntheticBeanCreatorClass();
 
     /**

--- a/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/spi/AISyntheticBeanCreatorClassProvider.java
+++ b/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/spi/AISyntheticBeanCreatorClassProvider.java
@@ -10,7 +10,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.ServiceLoader;
 
+/**
+ * Resolves the {@link SyntheticBeanCreator} class to use for LLM plugin beans by loading
+ * {@link AISyntheticBeanCreatorClassFactory} implementations via {@link ServiceLoader} and selecting the
+ * highest-priority one.
+ */
 public class AISyntheticBeanCreatorClassProvider {
+
+    /** Creates a new {@code AISyntheticBeanCreatorClassProvider}. */
+    public AISyntheticBeanCreatorClassProvider() {}
 
     private static final AISyntheticBeanCreatorClassFactory factory;
 
@@ -43,6 +51,11 @@ public class AISyntheticBeanCreatorClassProvider {
         }
     }
 
+    /**
+     * Returns the {@link SyntheticBeanCreator} class from the highest-priority factory.
+     *
+     * @return the synthetic bean creator class
+     */
     public static Class<? extends SyntheticBeanCreator<Object>> getSyntheticBeanCreatorClass() {
         return factory.getSyntheticBeanCreatorClass();
     }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/AgentAnnotationMeta.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/AgentAnnotationMeta.java
@@ -68,6 +68,9 @@ public record AgentAnnotationMeta(
      *   <li>{@code hasAnyAgentAnnotation} in the build-compatible extension
      *   <li>the {@code @Enhancement}/{@code @WithAnnotations} arrays in the build-compatible extension
      * </ol>
+     *
+     * @param interfaceClass the interface to inspect
+     * @return the detected meta, or {@code null} if no recognized annotation is found
      */
     public static AgentAnnotationMeta detect(Class<?> interfaceClass) {
         if (!interfaceClass.isInterface()) return null;
@@ -217,29 +220,48 @@ public record AgentAnnotationMeta(
         return null;
     }
 
-    /** Returns {@code true} when any recognized agent annotation is present on {@code interfaceClass}. */
+    /**
+     * Returns {@code true} when any recognized agent annotation is present on {@code interfaceClass}.
+     *
+     * @param interfaceClass the interface to inspect
+     * @return {@code true} if an agent annotation is present
+     */
     public static boolean isAgentInterface(Class<?> interfaceClass) {
         return detect(interfaceClass) != null;
     }
 
-    /** Expression-resolved name, equivalent to the annotation's {@code name()} after EL/Config expansion. */
+    /**
+     * Expression-resolved name, equivalent to the annotation's {@code name()} after EL/Config expansion.
+     *
+     * @return the resolved agent name
+     */
     public String name() {
         return CdiLookupHelper.resolveExpression(rawName);
     }
 
     /**
      * Expression-resolved description, equivalent to the annotation's {@code description()} after EL/Config expansion.
+     *
+     * @return the resolved agent description
      */
     public String description() {
         return CdiLookupHelper.resolveExpression(rawDescription);
     }
 
-    /** Expression-resolved output key, equivalent to the annotation's {@code outputKey()} after EL/Config expansion. */
+    /**
+     * Expression-resolved output key, equivalent to the annotation's {@code outputKey()} after EL/Config expansion.
+     *
+     * @return the resolved output key
+     */
     public String outputKey() {
         return CdiLookupHelper.resolveExpression(rawOutputKey);
     }
 
-    /** Returns {@code true} when a typed output key class other than {@link Agent.NoTypedKey} is set. */
+    /**
+     * Returns {@code true} when a typed output key class other than {@link Agent.NoTypedKey} is set.
+     *
+     * @return {@code true} if a typed output key is configured
+     */
     public boolean hasTypedOutputKey() {
         return rawTypedOutputKey != null && rawTypedOutputKey != Agent.NoTypedKey.class;
     }
@@ -247,6 +269,8 @@ public record AgentAnnotationMeta(
     /**
      * Expression-resolved summarized context agent names, equivalent to the annotation's {@code summarizedContext()}
      * after EL/Config expansion on each element.
+     *
+     * @return the resolved array of agent names for context summarization
      */
     public String[] summarizedContext() {
         if (rawSummarizedContext == null || rawSummarizedContext.length == 0) {

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/AgentTopologyType.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/AgentTopologyType.java
@@ -2,15 +2,23 @@ package dev.langchain4j.cdi.agent;
 
 /** Topology of an agentic system. */
 public enum AgentTopologyType {
+    /** A single agent with no orchestration. */
     SIMPLE,
+    /** Agents executed in sequence. */
     SEQUENCE,
+    /** Agents executed in a loop until a condition is met. */
     LOOP,
+    /** Agents executed in parallel. */
     PARALLEL,
     /** Maps a list of items over a single sub-agent, executing each mapping in parallel. */
     PARALLEL_MAPPER,
+    /** Routes to a sub-agent based on a condition. */
     CONDITIONAL,
+    /** A supervisor agent that delegates to and coordinates sub-agents. */
     SUPERVISOR,
+    /** A planner agent that decomposes tasks into steps. */
     PLANNER,
+    /** An agent communicating via the Agent-to-Agent protocol. */
     A2A,
     /** Wraps an MCP server tool as an agent. */
     MCP_CLIENT,

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
@@ -85,6 +85,9 @@ import java.util.stream.Collectors;
  */
 public class CommonAgentCreator {
 
+    /** Utility class — not instantiable. */
+    private CommonAgentCreator() {}
+
     private static final Logger LOGGER = Logger.getLogger(CommonAgentCreator.class.getName());
 
     /** CDI bean name prefix for agents that have no explicit name set in their annotation. */
@@ -130,6 +133,14 @@ public class CommonAgentCreator {
         return (X) Proxy.newProxyInstance(interfaceClass.getClassLoader(), interfaces.toArray(Class[]::new), handler);
     }
 
+    /**
+     * Creates an agent proxy for the given interface by inspecting its topology annotation.
+     *
+     * @param <X> the agent interface type
+     * @param lookup CDI lookup instance for resolving dependencies
+     * @param interfaceClass the annotated agent interface
+     * @return a proxy implementing the agent interface and standard framework interfaces
+     */
     public static <X> X create(Instance<Object> lookup, Class<X> interfaceClass) {
         RegisterSimpleAgent simple = interfaceClass.getAnnotation(RegisterSimpleAgent.class);
         if (simple != null) return createForSimple(lookup, interfaceClass, simple);
@@ -1000,6 +1011,11 @@ public class CommonAgentCreator {
 
     /** Marker interface allowing {@link #toAgentExecutor} to retrieve the underlying {@link HumanInTheLoop} spec. */
     public interface HumanInTheLoopHolder {
+        /**
+         * Returns the {@link HumanInTheLoop} spec associated with this agent.
+         *
+         * @return the human-in-the-loop specification
+         */
         HumanInTheLoop getHumanInTheLoop();
     }
 
@@ -1020,6 +1036,9 @@ public class CommonAgentCreator {
      *     .subAgents(CommonAgentCreator.toAgentExecutor(scorer), editor)
      *     .build();
      * }</pre>
+     *
+     * @param bean the CDI-managed agent bean to wrap
+     * @return an {@link AgentExecutor} wrapping the given bean
      */
     public static Object toAgentExecutor(Object bean) {
         return toAgentExecutor(bean, null);

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/aiservice/CdiLookupHelper.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/aiservice/CdiLookupHelper.java
@@ -30,7 +30,12 @@ public final class CdiLookupHelper {
 
     private CdiLookupHelper() {}
 
-    /** Returns {@code true} when {@code s} is non-null and contains at least one non-whitespace character. */
+    /**
+     * Returns {@code true} when {@code s} is non-null and contains at least one non-whitespace character.
+     *
+     * @param s the string to test
+     * @return {@code true} if the string is non-null and non-blank
+     */
     public static boolean hasText(String s) {
         return s != null && !s.isBlank();
     }
@@ -39,6 +44,9 @@ public final class CdiLookupHelper {
      * Resolves any expression embedded in {@code value} by applying all {@link ExpressionResolver} implementations
      * discovered via {@link ServiceLoader}, in discovery order. Returns {@code value} unchanged when no resolvers are
      * registered or the value is blank/null.
+     *
+     * @param value the raw annotation attribute value, possibly containing expressions
+     * @return the resolved value, or the original value if no resolvers matched
      */
     public static String resolveExpression(String value) {
         if (!hasText(value)) {
@@ -55,6 +63,12 @@ public final class CdiLookupHelper {
      * Resolve a CDI Instance for the given type and name. If name is {@code "#default"}, select the default bean of the
      * given type. If name is blank or null, returns null (meaning: do not attempt to resolve). Expression patterns in
      * {@code name} are expanded via {@link #resolveExpression(String)} before lookup.
+     *
+     * @param <X> the bean type
+     * @param lookup the CDI {@link Instance} used for bean resolution
+     * @param type the expected bean class
+     * @param name the bean name, {@code "#default"}, or an expression to resolve
+     * @return the matching {@link Instance}, or {@code null} if {@code name} is blank
      */
     public static <X> Instance<X> getInstance(Instance<Object> lookup, Class<X> type, String name) {
         String resolved = resolveExpression(name);
@@ -72,6 +86,12 @@ public final class CdiLookupHelper {
     /**
      * Resolve a single bean instance by type and name, returning null if unresolvable. Convenience wrapper around
      * {@link #getInstance} that extracts the bean.
+     *
+     * @param <X> the bean type
+     * @param lookup the CDI {@link Instance} used for bean resolution
+     * @param type the expected bean class
+     * @param name the bean name or expression to resolve
+     * @return the resolved bean instance, or {@code null} if not resolvable
      */
     public static <X> X resolveSingle(Instance<Object> lookup, Class<X> type, String name) {
         Instance<X> instance = getInstance(lookup, type, name);
@@ -85,6 +105,11 @@ public final class CdiLookupHelper {
      * Resolve guardrail instances by class. For each class, first attempts CDI lookup; if the bean is not resolvable,
      * falls back to instantiation via the no-arg constructor. Classes that fail both resolution paths are skipped with
      * a WARNING log.
+     *
+     * @param <G> the guardrail type
+     * @param lookup the CDI {@link Instance} used for bean resolution
+     * @param guardrailClasses the guardrail classes to resolve
+     * @return list of resolved guardrail instances
      */
     public static <G> List<G> resolveGuardrailsByClass(Instance<Object> lookup, Class<? extends G>[] guardrailClasses) {
         List<G> guardrails = new ArrayList<>(guardrailClasses.length);
@@ -110,6 +135,12 @@ public final class CdiLookupHelper {
     /**
      * Resolve guardrail instances by named CDI bean lookup. Names that cannot be resolved are skipped with a WARNING
      * log.
+     *
+     * @param <G> the guardrail type
+     * @param lookup the CDI {@link Instance} used for bean resolution
+     * @param type the guardrail class to select
+     * @param names the CDI bean names to look up
+     * @return list of resolved guardrail instances
      */
     public static <G> List<G> resolveGuardrailsByName(Instance<Object> lookup, Class<G> type, String[] names) {
         List<G> guardrails = new ArrayList<>(names.length);
@@ -131,6 +162,10 @@ public final class CdiLookupHelper {
 
     /**
      * Resolve tool instances by named CDI bean lookup. Names that cannot be resolved are skipped with a WARNING log.
+     *
+     * @param toolNames the CDI bean names of the tools to resolve
+     * @param lookup the CDI {@link Instance} used for bean resolution
+     * @return list of resolved tool instances
      */
     public static List<Object> resolveToolsByName(String[] toolNames, Instance<Object> lookup) {
         List<Object> tools = new ArrayList<>(toolNames.length);
@@ -153,6 +188,10 @@ public final class CdiLookupHelper {
      * Resolve tool instances from an array of tool classes. For each class, first attempts CDI lookup; if the bean is
      * not resolvable, falls back to instantiation via the no-arg constructor. Classes that fail both resolution paths
      * are skipped with a SEVERE log.
+     *
+     * @param toolClasses the tool classes to resolve or instantiate
+     * @param lookup the CDI {@link Instance} used for bean resolution
+     * @return list of resolved tool instances
      */
     public static List<Object> resolveToolInstances(Class<?>[] toolClasses, Instance<Object> lookup) {
         List<Object> tools = new ArrayList<>(toolClasses.length);
@@ -175,6 +214,12 @@ public final class CdiLookupHelper {
      * Resolve input guardrails using class-vs-name precedence. When both {@code guardrailClasses} and
      * {@code guardrailNames} are non-empty, classes take precedence and a WARNING is logged including
      * {@code interfaceName} so operators can identify the offending service.
+     *
+     * @param lookup the CDI {@link Instance} used for bean resolution
+     * @param guardrailClasses the input guardrail classes (takes precedence over names)
+     * @param guardrailNames the CDI bean names of input guardrails
+     * @param interfaceName the AI service interface name, used in warning messages
+     * @return list of resolved input guardrail instances
      */
     public static List<InputGuardrail> resolveInputGuardrails(
             Instance<Object> lookup,
@@ -199,6 +244,12 @@ public final class CdiLookupHelper {
      * Resolve output guardrails using class-vs-name precedence. When both {@code guardrailClasses} and
      * {@code guardrailNames} are non-empty, classes take precedence and a WARNING is logged including
      * {@code interfaceName} so operators can identify the offending service.
+     *
+     * @param lookup the CDI {@link Instance} used for bean resolution
+     * @param guardrailClasses the output guardrail classes (takes precedence over names)
+     * @param guardrailNames the CDI bean names of output guardrails
+     * @param interfaceName the AI service interface name, used in warning messages
+     * @return list of resolved output guardrail instances
      */
     public static List<OutputGuardrail> resolveOutputGuardrails(
             Instance<Object> lookup,

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/aiservice/CommonAIServiceCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/aiservice/CommonAIServiceCreator.java
@@ -29,11 +29,15 @@ import java.util.logging.Logger;
  */
 public class CommonAIServiceCreator {
 
+    /** Utility class — not instantiable. */
+    private CommonAIServiceCreator() {}
+
     private static final Logger LOGGER = Logger.getLogger(CommonAIServiceCreator.class.getName());
 
     /**
      * Create a LangChain4j AI service proxy for the given annotated interface.
      *
+     * @param <X> the AI service interface type
      * @param lookup CDI Instance used to resolve named beans (models, tools, memories, etc.).
      * @param interfaceClass the AI service interface annotated with {@link dev.langchain4j.cdi.spi.RegisterAIService}.
      * @return a runtime proxy implementing the given interface.

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/core/config/spi/LLMConfig.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/core/config/spi/LLMConfig.java
@@ -27,22 +27,43 @@ import java.util.stream.Stream;
  * MicroProfile/SmallRye Config, but kept minimal for portability.
  */
 public abstract class LLMConfig {
+
+    /** Creates a new configuration instance. */
+    protected LLMConfig() {}
+
+    /** Prefix used to identify CDI bean lookup values in configuration. */
     public static final String LOOKUP_PREFIX = "lookup:";
+
     Map<String, ProducerFunction<?>> producers = new ConcurrentHashMap<>();
 
     /** Prefix for all LLM beans properties. */
     public static final String PREFIX = "dev.langchain4j.cdi.plugin";
 
-    /** Called by @see LLMConfigProvider. */
+    /** Property key for a custom {@link ProducerFunction} bean producer. */
     public static final String PRODUCER = "defined_bean_producer";
 
+    /** Property key for the fully qualified class name of the bean. */
     public static final String CLASS = "class";
+
+    /** Property key for the CDI scope annotation of the bean. */
     public static final String SCOPE = "scope";
 
+    /** Initialize this configuration source. */
     public abstract void init();
 
+    /**
+     * Return all known property keys.
+     *
+     * @return set of property keys
+     */
     public abstract Set<String> getPropertyKeys();
 
+    /**
+     * Return the raw string value for the given key.
+     *
+     * @param key the property key
+     * @return the value, or {@code null} if absent
+     */
     public abstract String getValue(String key);
 
     /**
@@ -59,15 +80,36 @@ public abstract class LLMConfig {
                 .collect(Collectors.toSet());
     }
 
+    /**
+     * Return the raw configuration value for a bean property.
+     *
+     * @param beanName the logical bean name
+     * @param propertyName the property suffix (e.g. "class", "scope", or "config.xxx")
+     * @return the string value, or {@code null} if absent
+     */
     public String getBeanPropertyValue(String beanName, String propertyName) {
         String key = PREFIX + "." + beanName + "." + propertyName;
         return getValue(key);
     }
 
+    /**
+     * Register a custom bean producer function under the given name.
+     *
+     * @param producersName the logical name used to reference this producer in configuration
+     * @param producer the producer function to register
+     */
     public void registerProducer(String producersName, ProducerFunction<?> producer) {
         producers.putIfAbsent(producersName, producer);
     }
 
+    /**
+     * Return the bean property value converted to the requested type.
+     *
+     * @param beanName the logical bean name
+     * @param propertyName the property suffix
+     * @param type the target type for conversion
+     * @return the converted value, or {@code null} if absent
+     */
     public Object getBeanPropertyValue(String beanName, String propertyName, Type type) {
         ParameterizedType parameterizedType = null;
         Class<?> clazz;
@@ -123,6 +165,15 @@ public abstract class LLMConfig {
         return clazz.getConstructor(String.class).newInstance(stringValue);
     }
 
+    /**
+     * Return the bean property value, resolving CDI lookups when the value starts with {@link #LOOKUP_PREFIX}.
+     *
+     * @param lookup CDI Instance for resolving beans
+     * @param beanName the logical bean name
+     * @param propertyName the property suffix
+     * @param type the target type for conversion or lookup
+     * @return the resolved value, or {@code null} if absent
+     */
     @SuppressWarnings({"unchecked", "rawtypes"})
     public Object getBeanPropertyValue(Instance<Object> lookup, String beanName, String propertyName, Type type) {
         String stringValue = getBeanPropertyValue(beanName, propertyName);
@@ -225,7 +276,11 @@ public abstract class LLMConfig {
     private static java.util.function.Supplier<BeanManager> beanManagerSupplier =
             () -> CDI.current().getBeanManager();
 
-    /** For tests only: override how BeanManager is obtained. */
+    /**
+     * For tests only: override how BeanManager is obtained.
+     *
+     * @param supplier the supplier to use, or {@code null} to reset to the default
+     */
     public static void setBeanManagerSupplier(java.util.function.Supplier<BeanManager> supplier) {
         beanManagerSupplier = (supplier == null) ? () -> CDI.current().getBeanManager() : supplier;
     }
@@ -260,6 +315,12 @@ public abstract class LLMConfig {
         return lookup.select(clazz, NamedLiteral.of(lookupName));
     }
 
+    /**
+     * Return the configuration property names (without the common prefix) for the given bean.
+     *
+     * @param beanName the logical bean name
+     * @return set of property name suffixes under {@code config.}
+     */
     public Set<String> getPropertyNamesForBean(String beanName) {
         String configPrefix = PREFIX + "." + beanName + ".config.";
         return getPropertyKeys().stream()

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/core/config/spi/LLMConfigProvider.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/core/config/spi/LLMConfigProvider.java
@@ -12,6 +12,9 @@ import java.util.logging.Logger;
  */
 public class LLMConfigProvider {
 
+    /** Creates a new provider instance. */
+    public LLMConfigProvider() {}
+
     private static LLMConfig llmConfig;
     private static volatile boolean initialized = false;
     private static final Logger LOGGER = Logger.getLogger(LLMConfigProvider.class.getName());
@@ -33,6 +36,11 @@ public class LLMConfigProvider {
         LOGGER.fine("Found LLMConfig interface: " + llmConfig.getClass().getName());
     }
 
+    /**
+     * Return the lazily initialized {@link LLMConfig} instance discovered via {@link java.util.ServiceLoader}.
+     *
+     * @return the shared configuration instance
+     */
     public static LLMConfig getLlmConfig() {
         if (!initialized) {
             initialized = true;

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/core/config/spi/ProducerFunction.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/core/config/spi/ProducerFunction.java
@@ -12,9 +12,10 @@ public interface ProducerFunction<R> {
     /**
      * Produces a bean using its name and a lookup context.
      *
-     * @param lookup: lookup context.
-     * @param beanName: the name of the bean.
-     * @return the created bean.
+     * @param lookup the CDI lookup context
+     * @param beanName the name of the bean
+     * @param llmConfig the LLM configuration source
+     * @return the created bean
      */
     R produce(Instance<R> lookup, String beanName, LLMConfig llmConfig);
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/guardrail/CdiGuardrailServiceBuilderFactory.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/guardrail/CdiGuardrailServiceBuilderFactory.java
@@ -16,6 +16,9 @@ import dev.langchain4j.service.guardrail.spi.GuardrailServiceBuilderFactory;
  */
 public class CdiGuardrailServiceBuilderFactory implements GuardrailServiceBuilderFactory {
 
+    /** Creates a new factory instance. */
+    public CdiGuardrailServiceBuilderFactory() {}
+
     @Override
     public GuardrailService.Builder getBuilder(Class<?> aiServiceClass) {
         return new CdiGuardrailServiceBuilder(aiServiceClass);

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/plugin/CommonLLMPluginCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/plugin/CommonLLMPluginCreator.java
@@ -30,8 +30,19 @@ import java.util.stream.Stream;
  */
 public class CommonLLMPluginCreator {
 
+    /** Utility class — not instantiable. */
+    private CommonLLMPluginCreator() {}
+
+    /** Logger for this class. */
     public static final Logger LOGGER = Logger.getLogger(CommonLLMPluginCreator.class.getName());
 
+    /**
+     * Scan the given configuration for LLM bean definitions and pass each to the consumer.
+     *
+     * @param llmConfig the configuration source describing beans to create
+     * @param beanBuilder consumer that registers each discovered bean
+     * @throws ClassNotFoundException if a configured class cannot be loaded
+     */
     @SuppressWarnings("unchecked")
     public static void prepareAllLLMBeans(LLMConfig llmConfig, Consumer<BeanData> beanBuilder)
             throws ClassNotFoundException {
@@ -84,6 +95,16 @@ public class CommonLLMPluginCreator {
         }
     }
 
+    /**
+     * Holds the metadata needed to register a single LLM bean.
+     *
+     * @param targetClass the bean class to instantiate
+     * @param builderClass the inner Builder class used to construct the target, or {@code null} when a custom producer
+     *     is supplied
+     * @param scopeClass the CDI scope annotation for the bean
+     * @param beanName the logical bean name from configuration
+     * @param callback function that creates the bean instance given a CDI lookup context
+     */
     public record BeanData(
             Class<?> targetClass,
             Class<?> builderClass,
@@ -91,6 +112,16 @@ public class CommonLLMPluginCreator {
             String beanName,
             Function<Instance<Object>, Object> callback) {}
 
+    /**
+     * Create a single LLM bean instance via its builder, populated from configuration.
+     *
+     * @param lookup CDI Instance for resolving dependent beans
+     * @param llmConfig configuration source
+     * @param beanName logical name of the bean
+     * @param targetClass the class to instantiate
+     * @param builderClass the inner Builder class used to construct the target
+     * @return a fully configured instance of the target class
+     */
     public static Object create(
             Instance<Object> lookup,
             LLMConfig llmConfig,
@@ -238,6 +269,13 @@ public class CommonLLMPluginCreator {
         return currentClassFields;
     }
 
+    /**
+     * Load a class by name, trying the thread context classloader first.
+     *
+     * @param className fully qualified class name
+     * @return the loaded class
+     * @throws ClassNotFoundException if the class cannot be found
+     */
     public static Class<?> loadClass(String className) throws ClassNotFoundException {
         try {
             return Thread.currentThread().getContextClassLoader().loadClass(className);

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterA2AAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterA2AAgent.java
@@ -23,31 +23,76 @@ import java.lang.annotation.Target;
 @Stereotype
 public @interface RegisterA2AAgent {
 
+    /**
+     * CDI scope for the agent bean.
+     *
+     * @return the scope annotation class
+     */
     Class<? extends Annotation> scope() default ApplicationScoped.class;
 
+    /**
+     * Name of the agent.
+     *
+     * @return the agent name
+     */
     String name() default "";
 
+    /**
+     * Description of the agent.
+     *
+     * @return the agent description
+     */
     String description() default "";
 
+    /**
+     * Key for storing the agent output in the agentic scope.
+     *
+     * @return the output key
+     */
     String outputKey() default "";
 
+    /**
+     * Type-safe output key; takes precedence over {@link #outputKey()} when set.
+     *
+     * @return the typed output key class
+     */
     Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
+    /**
+     * Whether the agent should execute asynchronously.
+     *
+     * @return true if asynchronous
+     */
     boolean async() default false;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
      * scope, instead of making the agentic system's execution fail.
+     *
+     * @return true if the agent is optional
      */
     boolean optional() default false;
 
-    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    /**
+     * Names of other agents whose conversation context should be summarized and injected into this agent's prompt.
+     *
+     * @return the agent names for context summarization
+     */
     String[] summarizedContext() default {};
 
+    /**
+     * CDI bean name of an AgentListener to observe agent lifecycle events.
+     *
+     * @return the agent listener bean name
+     */
     String agentListenerName() default "";
 
     // TODO: add errorHandlerName when A2AAgentBuilder exposes errorHandler()
 
-    /** URL of the A2A server. Required. */
+    /**
+     * URL of the A2A server. Required.
+     *
+     * @return the A2A server URL
+     */
     String a2aServerUrl();
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterAIService.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterAIService.java
@@ -23,6 +23,11 @@ import java.lang.annotation.Target;
 @Stereotype
 public @interface RegisterAIService {
 
+    /**
+     * CDI scope for the AI service bean.
+     *
+     * @return the scope annotation class
+     */
     Class<? extends Annotation> scope() default RequestScoped.class;
 
     /**
@@ -30,21 +35,58 @@ public @interface RegisterAIService {
      * its no-arg constructor otherwise. Can be used together with {@link #toolProviderName()}: both are applied when
      * present. Avoid overlapping tool names across the two sources — LangChain4j will throw
      * {@code IllegalConfigurationException} at runtime if the same tool name appears more than once.
+     *
+     * @return the tool classes
      */
     Class<?>[] tools() default {};
 
+    /**
+     * CDI bean name of the chat model. Use "#default" for the default bean, or blank to skip.
+     *
+     * @return the chat model bean name
+     */
     String chatModelName() default "#default";
 
+    /**
+     * CDI bean name of the streaming chat model. Blank means no streaming model is wired.
+     *
+     * @return the streaming chat model bean name
+     */
     String streamingChatModelName() default "";
 
+    /**
+     * CDI bean name of the content retriever. Blank means no retriever is wired.
+     *
+     * @return the content retriever bean name
+     */
     String contentRetrieverName() default "";
 
+    /**
+     * CDI bean name of the moderation model. Blank means no moderation is applied.
+     *
+     * @return the moderation model bean name
+     */
     String moderationModelName() default "";
 
+    /**
+     * CDI bean name of the chat memory. Blank means no chat memory is wired.
+     *
+     * @return the chat memory bean name
+     */
     String chatMemoryName() default "";
 
+    /**
+     * CDI bean name of the chat memory provider. Blank means no provider is wired.
+     *
+     * @return the chat memory provider bean name
+     */
     String chatMemoryProviderName() default "";
 
+    /**
+     * CDI bean name of the retrieval augmentor. Takes precedence over content retriever when set.
+     *
+     * @return the retrieval augmentor bean name
+     */
     String retrievalAugmentorName() default "";
 
     /**
@@ -52,6 +94,8 @@ public @interface RegisterAIService {
      * together with {@link #tools()}: both are applied when present. Avoid overlapping tool names across the two
      * sources — LangChain4j will throw {@code IllegalConfigurationException} at runtime if the same tool name appears
      * more than once. Blank means no {@code ToolProvider} is wired.
+     *
+     * @return the tool provider bean name
      */
     String toolProviderName() default "";
 
@@ -59,6 +103,8 @@ public @interface RegisterAIService {
      * Input guardrail classes to validate messages before sending to the LLM. If a class is a CDI managed bean, the
      * bean instance is used; otherwise it is instantiated via its no-arg constructor. Mutually exclusive with
      * {@link #inputGuardrailNames()}: if both are specified, only the classes are used and the names are ignored.
+     *
+     * @return the input guardrail classes
      */
     Class<? extends InputGuardrail>[] inputGuardrails() default {};
 
@@ -66,6 +112,8 @@ public @interface RegisterAIService {
      * Output guardrail classes to validate LLM responses before returning them. If a class is a CDI managed bean, the
      * bean instance is used; otherwise it is instantiated via its no-arg constructor. Mutually exclusive with
      * {@link #outputGuardrailNames()}: if both are specified, only the classes are used and the names are ignored.
+     *
+     * @return the output guardrail classes
      */
     Class<? extends OutputGuardrail>[] outputGuardrails() default {};
 
@@ -73,6 +121,8 @@ public @interface RegisterAIService {
      * Named CDI beans implementing {@link InputGuardrail} to validate messages before sending to the LLM. Unresolvable
      * names are skipped with a WARNING log. Mutually exclusive with {@link #inputGuardrails()}: if both are specified,
      * only the classes are used and the names are ignored.
+     *
+     * @return the input guardrail bean names
      */
     String[] inputGuardrailNames() default {};
 
@@ -80,6 +130,8 @@ public @interface RegisterAIService {
      * Named CDI beans implementing {@link OutputGuardrail} to validate LLM responses before returning them.
      * Unresolvable names are skipped with a WARNING log. Mutually exclusive with {@link #outputGuardrails()}: if both
      * are specified, only the classes are used and the names are ignored.
+     *
+     * @return the output guardrail bean names
      */
     String[] outputGuardrailNames() default {};
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterConditionalAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterConditionalAgent.java
@@ -19,32 +19,88 @@ import java.lang.annotation.Target;
 @Stereotype
 public @interface RegisterConditionalAgent {
 
+    /**
+     * CDI scope for the agent bean.
+     *
+     * @return the scope annotation class
+     */
     Class<? extends Annotation> scope() default ApplicationScoped.class;
 
+    /**
+     * Name of the agent.
+     *
+     * @return the agent name
+     */
     String name() default "";
 
+    /**
+     * Description of the agent.
+     *
+     * @return the agent description
+     */
     String description() default "";
 
+    /**
+     * Key for storing the agent output in the agentic scope.
+     *
+     * @return the output key
+     */
     String outputKey() default "";
 
+    /**
+     * Type-safe output key; takes precedence over {@link #outputKey()} when set.
+     *
+     * @return the typed output key class
+     */
     Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
      * scope, instead of making the agentic system's execution fail.
+     *
+     * @return true if the agent is optional
      */
     boolean optional() default false;
 
-    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    /**
+     * Names of other agents whose conversation context should be summarized and injected into this agent's prompt.
+     *
+     * @return the agent names for context summarization
+     */
     String[] summarizedContext() default {};
 
+    /**
+     * CDI bean name of an AgentListener to observe agent lifecycle events.
+     *
+     * @return the agent listener bean name
+     */
     String agentListenerName() default "";
 
+    /**
+     * CDI bean name of an error handler invoked when a sub-agent fails.
+     *
+     * @return the error handler bean name
+     */
     String errorHandlerName() default "";
 
+    /**
+     * CDI bean name of a function that provides the agent output from the agentic scope.
+     *
+     * @return the output provider bean name
+     */
     String outputProviderName() default "";
 
+    /**
+     * CDI bean name of a consumer invoked before the agent executes.
+     *
+     * @return the before-call hook bean name
+     */
     String beforeCallName() default "";
 
+    /**
+     * Names of the sub-agents to route to based on conditions.
+     *
+     * @return the sub-agent names
+     */
     String[] subAgentNames() default {};
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterHumanInTheLoopAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterHumanInTheLoopAgent.java
@@ -20,27 +20,68 @@ import java.lang.annotation.Target;
 @Stereotype
 public @interface RegisterHumanInTheLoopAgent {
 
+    /**
+     * CDI scope for the agent bean.
+     *
+     * @return the scope annotation class
+     */
     Class<? extends Annotation> scope() default ApplicationScoped.class;
 
+    /**
+     * Name of the agent.
+     *
+     * @return the agent name
+     */
     String name() default "";
 
+    /**
+     * Description of the agent.
+     *
+     * @return the agent description
+     */
     String description() default "";
 
+    /**
+     * Key for storing the agent output in the agentic scope.
+     *
+     * @return the output key
+     */
     String outputKey() default "";
 
+    /**
+     * Type-safe output key; takes precedence over {@link #outputKey()} when set.
+     *
+     * @return the typed output key class
+     */
     Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
+    /**
+     * Whether the agent should execute asynchronously.
+     *
+     * @return true if asynchronous
+     */
     boolean async() default false;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
      * scope, instead of making the agentic system's execution fail.
+     *
+     * @return true if the agent is optional
      */
     boolean optional() default false;
 
-    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    /**
+     * Names of other agents whose conversation context should be summarized and injected into this agent's prompt.
+     *
+     * @return the agent names for context summarization
+     */
     String[] summarizedContext() default {};
 
+    /**
+     * CDI bean name of an AgentListener to observe agent lifecycle events.
+     *
+     * @return the agent listener bean name
+     */
     String agentListenerName() default "";
 
     // TODO: add errorHandlerName when HumanInTheLoop exposes errorHandler()
@@ -49,6 +90,8 @@ public @interface RegisterHumanInTheLoopAgent {
      * Name of a static method on the annotated interface that provides the human response. The method must accept a
      * single {@code AgenticScope} parameter and return {@code String}. When empty, the framework selects the only
      * matching static method automatically.
+     *
+     * @return the ask-user method name
      */
     String askUser() default "";
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterLoopAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterLoopAgent.java
@@ -17,44 +17,117 @@ import java.lang.annotation.Target;
 @Stereotype
 public @interface RegisterLoopAgent {
 
+    /**
+     * CDI scope for the agent bean.
+     *
+     * @return the scope annotation class
+     */
     Class<? extends Annotation> scope() default ApplicationScoped.class;
 
+    /**
+     * Name of the agent.
+     *
+     * @return the agent name
+     */
     String name() default "";
 
+    /**
+     * Description of the agent.
+     *
+     * @return the agent description
+     */
     String description() default "";
 
+    /**
+     * Key for storing the agent output in the agentic scope.
+     *
+     * @return the output key
+     */
     String outputKey() default "";
 
+    /**
+     * Type-safe output key; takes precedence over {@link #outputKey()} when set.
+     *
+     * @return the typed output key class
+     */
     Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
      * scope, instead of making the agentic system's execution fail.
+     *
+     * @return true if the agent is optional
      */
     boolean optional() default false;
 
-    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    /**
+     * Names of other agents whose conversation context should be summarized and injected into this agent's prompt.
+     *
+     * @return the agent names for context summarization
+     */
     String[] summarizedContext() default {};
 
+    /**
+     * CDI bean name of an AgentListener to observe agent lifecycle events.
+     *
+     * @return the agent listener bean name
+     */
     String agentListenerName() default "";
 
+    /**
+     * CDI bean name of an error handler invoked when a sub-agent fails.
+     *
+     * @return the error handler bean name
+     */
     String errorHandlerName() default "";
 
+    /**
+     * CDI bean name of a function that provides the agent output from the agentic scope.
+     *
+     * @return the output provider bean name
+     */
     String outputProviderName() default "";
 
+    /**
+     * CDI bean name of a consumer invoked before the agent executes.
+     *
+     * @return the before-call hook bean name
+     */
     String beforeCallName() default "";
 
+    /**
+     * Names of the sub-agents to execute in each loop iteration.
+     *
+     * @return the sub-agent names
+     */
     String[] subAgentNames() default {};
 
+    /**
+     * Maximum number of loop iterations.
+     *
+     * @return the maximum iteration count
+     */
     int maxIterations() default 10;
 
     /**
      * CDI bean name of a {@code Predicate<AgenticScope>} or {@code BiPredicate<AgenticScope, Integer>} that controls
      * early exit from the loop. Blank means no early exit condition is applied.
+     *
+     * @return the exit condition bean name
      */
     String exitConditionName() default "";
 
+    /**
+     * Description of the exit condition for LLM prompting.
+     *
+     * @return the exit condition description
+     */
     String exitConditionDescription() default "";
 
+    /**
+     * Whether the exit condition should be tested after each iteration rather than only at the end.
+     *
+     * @return true to test the exit condition after each iteration
+     */
     boolean testAfterEachIteration() default false;
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterMcpClientAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterMcpClientAgent.java
@@ -21,37 +21,90 @@ import java.lang.annotation.Target;
 @Stereotype
 public @interface RegisterMcpClientAgent {
 
+    /**
+     * CDI scope for the agent bean.
+     *
+     * @return the scope annotation class
+     */
     Class<? extends Annotation> scope() default ApplicationScoped.class;
 
+    /**
+     * Name of the agent.
+     *
+     * @return the agent name
+     */
     String name() default "";
 
+    /**
+     * Description of the agent.
+     *
+     * @return the agent description
+     */
     String description() default "";
 
+    /**
+     * Key for storing the agent output in the agentic scope.
+     *
+     * @return the output key
+     */
     String outputKey() default "";
 
+    /**
+     * Type-safe output key; takes precedence over {@link #outputKey()} when set.
+     *
+     * @return the typed output key class
+     */
     Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
+    /**
+     * Whether the agent should execute asynchronously.
+     *
+     * @return true if asynchronous
+     */
     boolean async() default false;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
      * scope, instead of making the agentic system's execution fail.
+     *
+     * @return true if the agent is optional
      */
     boolean optional() default false;
 
-    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    /**
+     * Names of other agents whose conversation context should be summarized and injected into this agent's prompt.
+     *
+     * @return the agent names for context summarization
+     */
     String[] summarizedContext() default {};
 
+    /**
+     * CDI bean name of an AgentListener to observe agent lifecycle events.
+     *
+     * @return the agent listener bean name
+     */
     String agentListenerName() default "";
 
     // TODO: add errorHandlerName when McpService exposes errorHandler()
 
-    /** CDI bean name of the MCP client object. Required. */
+    /**
+     * CDI bean name of the MCP client object. Required.
+     *
+     * @return the MCP client bean name
+     */
     String mcpClientName();
 
-    /** Name of the MCP server tool to invoke. Required. */
+    /**
+     * Name of the MCP server tool to invoke. Required.
+     *
+     * @return the MCP tool name
+     */
     String mcpToolName();
 
-    /** Keys of the input arguments read from {@link dev.langchain4j.agentic.scope.AgenticScope}. */
+    /**
+     * Keys of the input arguments read from {@link dev.langchain4j.agentic.scope.AgenticScope}.
+     *
+     * @return the input argument keys
+     */
     String[] mcpInputKeys() default {};
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterParallelAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterParallelAgent.java
@@ -17,32 +17,88 @@ import java.lang.annotation.Target;
 @Stereotype
 public @interface RegisterParallelAgent {
 
+    /**
+     * CDI scope for the agent bean.
+     *
+     * @return the scope annotation class
+     */
     Class<? extends Annotation> scope() default ApplicationScoped.class;
 
+    /**
+     * Name of the agent.
+     *
+     * @return the agent name
+     */
     String name() default "";
 
+    /**
+     * Description of the agent.
+     *
+     * @return the agent description
+     */
     String description() default "";
 
+    /**
+     * Key for storing the agent output in the agentic scope.
+     *
+     * @return the output key
+     */
     String outputKey() default "";
 
+    /**
+     * Type-safe output key; takes precedence over {@link #outputKey()} when set.
+     *
+     * @return the typed output key class
+     */
     Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
      * scope, instead of making the agentic system's execution fail.
+     *
+     * @return true if the agent is optional
      */
     boolean optional() default false;
 
-    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    /**
+     * Names of other agents whose conversation context should be summarized and injected into this agent's prompt.
+     *
+     * @return the agent names for context summarization
+     */
     String[] summarizedContext() default {};
 
+    /**
+     * CDI bean name of an AgentListener to observe agent lifecycle events.
+     *
+     * @return the agent listener bean name
+     */
     String agentListenerName() default "";
 
+    /**
+     * CDI bean name of an error handler invoked when a sub-agent fails.
+     *
+     * @return the error handler bean name
+     */
     String errorHandlerName() default "";
 
+    /**
+     * CDI bean name of a function that provides the agent output from the agentic scope.
+     *
+     * @return the output provider bean name
+     */
     String outputProviderName() default "";
 
+    /**
+     * CDI bean name of a consumer invoked before the agent executes.
+     *
+     * @return the before-call hook bean name
+     */
     String beforeCallName() default "";
 
+    /**
+     * Names of the sub-agents to run in parallel.
+     *
+     * @return the sub-agent names
+     */
     String[] subAgentNames() default {};
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterParallelMapperAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterParallelMapperAgent.java
@@ -23,35 +23,95 @@ import java.lang.annotation.Target;
 @Stereotype
 public @interface RegisterParallelMapperAgent {
 
+    /**
+     * CDI scope for the agent bean.
+     *
+     * @return the scope annotation class
+     */
     Class<? extends Annotation> scope() default ApplicationScoped.class;
 
+    /**
+     * Name of the agent.
+     *
+     * @return the agent name
+     */
     String name() default "";
 
+    /**
+     * Description of the agent.
+     *
+     * @return the agent description
+     */
     String description() default "";
 
+    /**
+     * Key for storing the agent output in the agentic scope.
+     *
+     * @return the output key
+     */
     String outputKey() default "";
 
+    /**
+     * Type-safe output key; takes precedence over {@link #outputKey()} when set.
+     *
+     * @return the typed output key class
+     */
     Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
      * scope, instead of making the agentic system's execution fail.
+     *
+     * @return true if the agent is optional
      */
     boolean optional() default false;
 
-    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    /**
+     * Names of other agents whose conversation context should be summarized and injected into this agent's prompt.
+     *
+     * @return the agent names for context summarization
+     */
     String[] summarizedContext() default {};
 
+    /**
+     * CDI bean name of an AgentListener to observe agent lifecycle events.
+     *
+     * @return the agent listener bean name
+     */
     String agentListenerName() default "";
 
+    /**
+     * CDI bean name of an error handler invoked when a sub-agent fails.
+     *
+     * @return the error handler bean name
+     */
     String errorHandlerName() default "";
 
+    /**
+     * CDI bean name of a function that provides the agent output from the agentic scope.
+     *
+     * @return the output provider bean name
+     */
     String outputProviderName() default "";
 
+    /**
+     * CDI bean name of a consumer invoked before the agent executes.
+     *
+     * @return the before-call hook bean name
+     */
     String beforeCallName() default "";
 
+    /**
+     * Names of the sub-agents; the first entry is the worker applied to each item.
+     *
+     * @return the sub-agent names
+     */
     String[] subAgentNames() default {};
 
-    /** Key in {@link dev.langchain4j.agentic.scope.AgenticScope} that holds the list of items to map over. Required. */
+    /**
+     * Key in {@link dev.langchain4j.agentic.scope.AgenticScope} that holds the list of items to map over. Required.
+     *
+     * @return the items key
+     */
     String itemsKey();
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterPlannerAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterPlannerAgent.java
@@ -23,34 +23,95 @@ import java.lang.annotation.Target;
 @Stereotype
 public @interface RegisterPlannerAgent {
 
+    /**
+     * CDI scope for the agent bean.
+     *
+     * @return the scope annotation class
+     */
     Class<? extends Annotation> scope() default ApplicationScoped.class;
 
+    /**
+     * Name of the agent.
+     *
+     * @return the agent name
+     */
     String name() default "";
 
+    /**
+     * Description of the agent.
+     *
+     * @return the agent description
+     */
     String description() default "";
 
+    /**
+     * Key for storing the agent output in the agentic scope.
+     *
+     * @return the output key
+     */
     String outputKey() default "";
 
+    /**
+     * Type-safe output key; takes precedence over {@link #outputKey()} when set.
+     *
+     * @return the typed output key class
+     */
     Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
      * scope, instead of making the agentic system's execution fail.
+     *
+     * @return true if the agent is optional
      */
     boolean optional() default false;
 
-    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    /**
+     * Names of other agents whose conversation context should be summarized and injected into this agent's prompt.
+     *
+     * @return the agent names for context summarization
+     */
     String[] summarizedContext() default {};
 
+    /**
+     * CDI bean name of an AgentListener to observe agent lifecycle events.
+     *
+     * @return the agent listener bean name
+     */
     String agentListenerName() default "";
 
+    /**
+     * CDI bean name of an error handler invoked when a sub-agent fails.
+     *
+     * @return the error handler bean name
+     */
     String errorHandlerName() default "";
 
+    /**
+     * CDI bean name of a function that provides the agent output from the agentic scope.
+     *
+     * @return the output provider bean name
+     */
     String outputProviderName() default "";
 
+    /**
+     * CDI bean name of a consumer invoked before the agent executes.
+     *
+     * @return the before-call hook bean name
+     */
     String beforeCallName() default "";
 
+    /**
+     * Names of the sub-agents available for the planner.
+     *
+     * @return the sub-agent names
+     */
     String[] subAgentNames() default {};
 
+    /**
+     * CDI bean name of the Planner implementation. Blank means the interface must declare a @PlannerSupplier method.
+     *
+     * @return the planner bean name
+     */
     String plannerName() default "";
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSequenceAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSequenceAgent.java
@@ -17,32 +17,88 @@ import java.lang.annotation.Target;
 @Stereotype
 public @interface RegisterSequenceAgent {
 
+    /**
+     * CDI scope for the agent bean.
+     *
+     * @return the scope annotation class
+     */
     Class<? extends Annotation> scope() default ApplicationScoped.class;
 
+    /**
+     * Name of the agent.
+     *
+     * @return the agent name
+     */
     String name() default "";
 
+    /**
+     * Description of the agent.
+     *
+     * @return the agent description
+     */
     String description() default "";
 
+    /**
+     * Key for storing the agent output in the agentic scope.
+     *
+     * @return the output key
+     */
     String outputKey() default "";
 
+    /**
+     * Type-safe output key; takes precedence over {@link #outputKey()} when set.
+     *
+     * @return the typed output key class
+     */
     Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
      * scope, instead of making the agentic system's execution fail.
+     *
+     * @return true if the agent is optional
      */
     boolean optional() default false;
 
-    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    /**
+     * Names of other agents whose conversation context should be summarized and injected into this agent's prompt.
+     *
+     * @return the agent names for context summarization
+     */
     String[] summarizedContext() default {};
 
+    /**
+     * CDI bean name of an AgentListener to observe agent lifecycle events.
+     *
+     * @return the agent listener bean name
+     */
     String agentListenerName() default "";
 
+    /**
+     * CDI bean name of an error handler invoked when a sub-agent fails.
+     *
+     * @return the error handler bean name
+     */
     String errorHandlerName() default "";
 
+    /**
+     * CDI bean name of a function that provides the agent output from the agentic scope.
+     *
+     * @return the output provider bean name
+     */
     String outputProviderName() default "";
 
+    /**
+     * CDI bean name of a consumer invoked before the agent executes.
+     *
+     * @return the before-call hook bean name
+     */
     String beforeCallName() default "";
 
+    /**
+     * Names of the sub-agents to execute in sequence.
+     *
+     * @return the sub-agent names
+     */
     String[] subAgentNames() default {};
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSimpleAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSimpleAgent.java
@@ -25,33 +25,84 @@ import java.lang.annotation.Target;
 @Stereotype
 public @interface RegisterSimpleAgent {
 
+    /**
+     * CDI scope for the agent bean.
+     *
+     * @return the scope annotation class
+     */
     Class<? extends Annotation> scope() default ApplicationScoped.class;
 
+    /**
+     * Name of the agent.
+     *
+     * @return the agent name
+     */
     String name() default "";
 
+    /**
+     * Description of the agent.
+     *
+     * @return the agent description
+     */
     String description() default "";
 
+    /**
+     * Key for storing the agent output in the agentic scope.
+     *
+     * @return the output key
+     */
     String outputKey() default "";
 
+    /**
+     * Type-safe output key; takes precedence over {@link #outputKey()} when set.
+     *
+     * @return the typed output key class
+     */
     Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
+    /**
+     * Whether the agent should execute asynchronously.
+     *
+     * @return true if asynchronous
+     */
     boolean async() default false;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
      * scope, instead of making the agentic system's execution fail.
+     *
+     * @return true if the agent is optional
      */
     boolean optional() default false;
 
-    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    /**
+     * Names of other agents whose conversation context should be summarized and injected into this agent's prompt.
+     *
+     * @return the agent names for context summarization
+     */
     String[] summarizedContext() default {};
 
+    /**
+     * CDI bean name of an AgentListener to observe agent lifecycle events.
+     *
+     * @return the agent listener bean name
+     */
     String agentListenerName() default "";
 
     // TODO: add errorHandlerName when AgentBuilder exposes errorHandler()
 
+    /**
+     * CDI bean name of the chat model. Use {@code "#default"} for the default bean, or blank to skip.
+     *
+     * @return the chat model bean name
+     */
     String chatModelName() default "#default";
 
+    /**
+     * CDI bean name of the streaming chat model. Blank means no streaming model is wired.
+     *
+     * @return the streaming chat model bean name
+     */
     String streamingChatModelName() default "";
 
     /**
@@ -59,29 +110,60 @@ public @interface RegisterSimpleAgent {
      * no-arg constructor otherwise. Can be used together with {@link #toolNames()} and {@link #toolProviderName()}: all
      * present sources are applied. Avoid overlapping tool names across sources — LangChain4j will throw
      * {@code IllegalConfigurationException} at runtime if the same tool name appears more than once.
+     *
+     * @return the tool classes
      */
     Class<?>[] tools() default {};
 
     /**
      * CDI bean names of tool objects to register. Each name must resolve to a {@code @Named} CDI bean. Can be used
      * together with {@link #tools()} and {@link #toolProviderName()}.
+     *
+     * @return the tool bean names
      */
     String[] toolNames() default {};
 
+    /**
+     * CDI bean name of the tool provider. Blank means no provider is wired.
+     *
+     * @return the tool provider bean name
+     */
     String toolProviderName() default "";
 
+    /**
+     * CDI bean name of the chat memory. Blank means no chat memory is wired.
+     *
+     * @return the chat memory bean name
+     */
     String chatMemoryName() default "";
 
+    /**
+     * CDI bean name of the chat memory provider. Blank means no provider is wired.
+     *
+     * @return the chat memory provider bean name
+     */
     String chatMemoryProviderName() default "";
 
+    /**
+     * CDI bean name of the content retriever. Blank means no retriever is wired.
+     *
+     * @return the content retriever bean name
+     */
     String contentRetrieverName() default "";
 
+    /**
+     * CDI bean name of the retrieval augmentor. Takes precedence over content retriever when set.
+     *
+     * @return the retrieval augmentor bean name
+     */
     String retrievalAugmentorName() default "";
 
     /**
      * Input guardrail classes to validate messages before sending to the LLM. If a class is a CDI managed bean, the
      * bean instance is used; otherwise it is instantiated via its no-arg constructor. Mutually exclusive with
      * {@link #inputGuardrailNames()}: if both are specified, only the classes are used and the names are ignored.
+     *
+     * @return the input guardrail classes
      */
     Class<? extends InputGuardrail>[] inputGuardrails() default {};
 
@@ -89,6 +171,8 @@ public @interface RegisterSimpleAgent {
      * Output guardrail classes to validate LLM responses before returning them. If a class is a CDI managed bean, the
      * bean instance is used; otherwise it is instantiated via its no-arg constructor. Mutually exclusive with
      * {@link #outputGuardrailNames()}: if both are specified, only the classes are used and the names are ignored.
+     *
+     * @return the output guardrail classes
      */
     Class<? extends OutputGuardrail>[] outputGuardrails() default {};
 
@@ -96,6 +180,8 @@ public @interface RegisterSimpleAgent {
      * Named CDI beans implementing {@link InputGuardrail} to validate messages before sending to the LLM. Unresolvable
      * names are skipped with a WARNING log. Mutually exclusive with {@link #inputGuardrails()}: if both are specified,
      * only the classes are used and the names are ignored.
+     *
+     * @return the input guardrail bean names
      */
     String[] inputGuardrailNames() default {};
 
@@ -103,6 +189,8 @@ public @interface RegisterSimpleAgent {
      * Named CDI beans implementing {@link OutputGuardrail} to validate LLM responses before returning them.
      * Unresolvable names are skipped with a WARNING log. Mutually exclusive with {@link #outputGuardrails()}: if both
      * are specified, only the classes are used and the names are ignored.
+     *
+     * @return the output guardrail bean names
      */
     String[] outputGuardrailNames() default {};
 }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSupervisorAgent.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/spi/RegisterSupervisorAgent.java
@@ -19,44 +19,125 @@ import java.lang.annotation.Target;
 @Stereotype
 public @interface RegisterSupervisorAgent {
 
+    /**
+     * CDI scope for the agent bean.
+     *
+     * @return the scope annotation class
+     */
     Class<? extends Annotation> scope() default ApplicationScoped.class;
 
+    /**
+     * Name of the agent.
+     *
+     * @return the agent name
+     */
     String name() default "";
 
+    /**
+     * Description of the agent.
+     *
+     * @return the agent description
+     */
     String description() default "";
 
+    /**
+     * Key for storing the agent output in the agentic scope.
+     *
+     * @return the output key
+     */
     String outputKey() default "";
 
+    /**
+     * Type-safe output key; takes precedence over {@link #outputKey()} when set.
+     *
+     * @return the typed output key class
+     */
     Class<? extends TypedKey<?>> typedOutputKey() default Agent.NoTypedKey.class;
 
     /**
      * If true, the agent's execution will be silently skipped when any of its arguments is missing in the agentic
      * scope, instead of making the agentic system's execution fail.
+     *
+     * @return true if the agent is optional
      */
     boolean optional() default false;
 
-    /** Names of other agents whose conversation context should be summarized and injected into this agent's prompt. */
+    /**
+     * Names of other agents whose conversation context should be summarized and injected into this agent's prompt.
+     *
+     * @return the agent names for context summarization
+     */
     String[] summarizedContext() default {};
 
+    /**
+     * CDI bean name of an AgentListener to observe agent lifecycle events.
+     *
+     * @return the agent listener bean name
+     */
     String agentListenerName() default "";
 
+    /**
+     * CDI bean name of an error handler invoked when a sub-agent fails.
+     *
+     * @return the error handler bean name
+     */
     String errorHandlerName() default "";
 
+    /**
+     * CDI bean name of a function that provides the agent output from the agentic scope.
+     *
+     * @return the output provider bean name
+     */
     String outputProviderName() default "";
 
     // TODO: add beforeCallName when SupervisorAgentService exposes beforeCall()
 
+    /**
+     * Names of the sub-agents available for the supervisor to orchestrate.
+     *
+     * @return the sub-agent names
+     */
     String[] subAgentNames() default {};
 
+    /**
+     * CDI bean name of the chat model used by the supervisor. Use {@code "#default"} for the default bean.
+     *
+     * @return the chat model bean name
+     */
     String chatModelName() default "#default";
 
+    /**
+     * CDI bean name of the chat memory provider. Blank means no provider is wired.
+     *
+     * @return the chat memory provider bean name
+     */
     String chatMemoryProviderName() default "";
 
+    /**
+     * Maximum number of sub-agent invocations the supervisor may perform.
+     *
+     * @return the maximum invocation count
+     */
     int maxAgentsInvocations() default 10;
 
+    /**
+     * Additional context information for the supervisor prompt.
+     *
+     * @return the supervisor context
+     */
     String supervisorContext() default "";
 
+    /**
+     * Strategy for how sub-agent context is shared with the supervisor.
+     *
+     * @return the context strategy
+     */
     SupervisorContextStrategy supervisorContextStrategy() default SupervisorContextStrategy.CHAT_MEMORY;
 
+    /**
+     * Strategy for selecting the final response from sub-agent results.
+     *
+     * @return the response strategy
+     */
     SupervisorResponseStrategy supervisorResponseStrategy() default SupervisorResponseStrategy.LAST;
 }

--- a/langchain4j-cdi-el/src/main/java/dev/langchain4j/cdi/el/JakartaELExpressionResolver.java
+++ b/langchain4j-cdi-el/src/main/java/dev/langchain4j/cdi/el/JakartaELExpressionResolver.java
@@ -28,6 +28,9 @@ public class JakartaELExpressionResolver implements ExpressionResolver {
     private static final Logger LOGGER = Logger.getLogger(JakartaELExpressionResolver.class.getName());
     private static final Pattern EL_PATTERN = Pattern.compile("^#\\{(.+)\\}$");
 
+    /** Creates a new {@code JakartaELExpressionResolver}. */
+    public JakartaELExpressionResolver() {}
+
     @Override
     public String resolve(String value) {
         Matcher matcher = EL_PATTERN.matcher(value);

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/AgentChatRestService.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/AgentChatRestService.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
+/** JAX-RS endpoint for agent chat integration testing. */
 @Path("/agent-chat")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -15,6 +16,15 @@ public class AgentChatRestService {
     @Inject
     AgentChatService agentChatService;
 
+    /** Creates a new instance. */
+    public AgentChatRestService() {}
+
+    /**
+     * Forwards a chat request to the agent chat service.
+     *
+     * @param chatRequest the user message
+     * @return the agent response
+     */
     @POST
     public String postChat(String chatRequest) {
         return agentChatService.chat(chatRequest);

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/AgentChatService.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/AgentChatService.java
@@ -6,10 +6,17 @@ import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
 import jakarta.enterprise.context.ApplicationScoped;
 
+/** Simple agent AI service for integration testing. */
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterSimpleAgent(chatModelName = "chat-model", scope = ApplicationScoped.class)
 public interface AgentChatService {
 
+    /**
+     * Sends a question to the agent.
+     *
+     * @param question the user question
+     * @return the agent response
+     */
     @SystemMessage("You are a helpful assistant.")
     @UserMessage("{question}")
     String chat(@V("question") String question);

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/ChatAiService.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/ChatAiService.java
@@ -3,10 +3,17 @@ package dev.langchain4j.cdi.integrationtests;
 import dev.langchain4j.cdi.spi.RegisterAIService;
 import dev.langchain4j.service.SystemMessage;
 
+/** AI chat service for integration testing. */
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(chatModelName = "chat-model")
 public interface ChatAiService {
 
+    /**
+     * Sends a question to the chat model.
+     *
+     * @param question the user question
+     * @return the model response
+     */
     @SystemMessage("""
             my system message.
             """)

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/ChatRestService.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/ChatRestService.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
+/** JAX-RS endpoint for chat integration testing. */
 @Path("/chat")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -15,6 +16,15 @@ public class ChatRestService {
     @Inject
     ChatAiService chatAiService;
 
+    /** Creates a new instance. */
+    public ChatRestService() {}
+
+    /**
+     * Forwards a chat request to the AI service.
+     *
+     * @param chatRequest the user message
+     * @return the AI response
+     */
     @POST
     public String postChat(String chatRequest) {
         return chatAiService.chat(chatRequest);

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/GuardrailChatAiService.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/GuardrailChatAiService.java
@@ -3,6 +3,7 @@ package dev.langchain4j.cdi.integrationtests;
 import dev.langchain4j.cdi.spi.RegisterAIService;
 import dev.langchain4j.service.SystemMessage;
 
+/** AI chat service with guardrails for integration testing. */
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
         chatModelName = "chat-model",
@@ -10,6 +11,12 @@ import dev.langchain4j.service.SystemMessage;
         outputGuardrails = {PassThroughOutputGuardrail.class})
 public interface GuardrailChatAiService {
 
+    /**
+     * Sends a question to the guarded chat model.
+     *
+     * @param question the user question
+     * @return the model response
+     */
     @SystemMessage("""
             my system message.
             """)

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/GuardrailChatRestService.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/GuardrailChatRestService.java
@@ -8,6 +8,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+/** JAX-RS endpoint for guarded chat integration testing. */
 @Path("/guarded-chat")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -16,6 +17,15 @@ public class GuardrailChatRestService {
     @Inject
     GuardrailChatAiService guardrailChatAiService;
 
+    /** Creates a new instance. */
+    public GuardrailChatRestService() {}
+
+    /**
+     * Forwards a chat request to the guarded AI service.
+     *
+     * @param chatRequest the user message
+     * @return the response, or 400 if a guardrail rejects the message
+     */
     @POST
     public Response postChat(String chatRequest) {
         try {

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/HumanInTheLoopEntryMethodAgentService.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/HumanInTheLoopEntryMethodAgentService.java
@@ -4,6 +4,7 @@ import dev.langchain4j.agentic.scope.AgenticScope;
 import dev.langchain4j.cdi.spi.RegisterHumanInTheLoopAgent;
 import dev.langchain4j.service.V;
 
+/** Human-in-the-loop agent using an entry method for integration testing. */
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterHumanInTheLoopAgent(
         name = "hitl-entry-method-agent",
@@ -11,9 +12,21 @@ import dev.langchain4j.service.V;
         outputKey = "entryMethodResult")
 public interface HumanInTheLoopEntryMethodAgentService {
 
+    /**
+     * Simulates asking the user for input.
+     *
+     * @param scope the agentic scope
+     * @return a fixed test response
+     */
     static String askUser(AgenticScope scope) {
         return "entry-method-response";
     }
 
+    /**
+     * Processes the given input.
+     *
+     * @param input the input to process
+     * @return the processing result
+     */
     String process(@V("input") String input);
 }

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/HumanInTheLoopMarkerAgentService.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/HumanInTheLoopMarkerAgentService.java
@@ -3,6 +3,7 @@ package dev.langchain4j.cdi.integrationtests;
 import dev.langchain4j.agentic.scope.AgenticScope;
 import dev.langchain4j.cdi.spi.RegisterHumanInTheLoopAgent;
 
+/** Human-in-the-loop agent using marker interface for integration testing. */
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterHumanInTheLoopAgent(
         name = "hitl-marker-agent",
@@ -10,6 +11,12 @@ import dev.langchain4j.cdi.spi.RegisterHumanInTheLoopAgent;
         outputKey = "markerResult")
 public interface HumanInTheLoopMarkerAgentService {
 
+    /**
+     * Simulates asking the user for input.
+     *
+     * @param scope the agentic scope
+     * @return a fixed test response
+     */
     static String askUser(AgenticScope scope) {
         return "marker-response";
     }

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/NoEmptyMessageInputGuardrail.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/NoEmptyMessageInputGuardrail.java
@@ -5,8 +5,12 @@ import dev.langchain4j.guardrail.InputGuardrail;
 import dev.langchain4j.guardrail.InputGuardrailResult;
 import jakarta.enterprise.context.ApplicationScoped;
 
+/** Input guardrail that rejects empty or blank messages. */
 @ApplicationScoped
 public class NoEmptyMessageInputGuardrail implements InputGuardrail {
+
+    /** Creates a new instance. */
+    public NoEmptyMessageInputGuardrail() {}
 
     @Override
     public InputGuardrailResult validate(UserMessage userMessage) {

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/PassThroughOutputGuardrail.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-common/src/main/java/dev/langchain4j/cdi/integrationtests/PassThroughOutputGuardrail.java
@@ -5,8 +5,12 @@ import dev.langchain4j.guardrail.OutputGuardrail;
 import dev.langchain4j.guardrail.OutputGuardrailResult;
 import jakarta.enterprise.context.ApplicationScoped;
 
+/** Output guardrail that always passes through. */
 @ApplicationScoped
 public class PassThroughOutputGuardrail implements OutputGuardrail {
+
+    /** Creates a new instance. */
+    public PassThroughOutputGuardrail() {}
 
     @Override
     public OutputGuardrailResult validate(AiMessage responseFromLLM) {

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-helidon/src/main/java/dev/langchain4j/cdi/integrationtests/ChatModelMock.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-helidon/src/main/java/dev/langchain4j/cdi/integrationtests/ChatModelMock.java
@@ -7,11 +7,20 @@ import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.output.TokenUsage;
 import jakarta.enterprise.context.ApplicationScoped;
 
+/** Mock {@link ChatModel} for Helidon integration testing. */
 @ApplicationScoped
 public class ChatModelMock implements ChatModel {
 
+    /** Creates a new instance. */
+    public ChatModelMock() {}
+
     private ChatResponse fixedChatResponse;
 
+    /**
+     * Sets a fixed response to return for all chat requests.
+     *
+     * @param fixedChatResponse the response to return
+     */
     public void setFixedChatResponse(ChatResponse fixedChatResponse) {
         this.fixedChatResponse = fixedChatResponse;
     }
@@ -27,12 +36,26 @@ public class ChatModelMock implements ChatModel {
                 .build();
     }
 
+    /**
+     * Creates a new builder.
+     *
+     * @return a new builder instance
+     */
     public static ChatModelMockBuilder builder() {
         return new ChatModelMockBuilder();
     }
 
+    /** Builder for {@link ChatModelMock}. */
     public static class ChatModelMockBuilder {
 
+        /** Creates a new instance. */
+        public ChatModelMockBuilder() {}
+
+        /**
+         * Builds the mock.
+         *
+         * @return a new {@link ChatModelMock}
+         */
         public ChatModelMock build() {
             return new ChatModelMock();
         }

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-jakartaee/langchain4j-cdi-integration-tests-jakartaee-common-wildfly/src/main/java/dev/langchain4j/cdi/core/integrationtests/ChatModelMock.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-jakartaee/langchain4j-cdi-integration-tests-jakartaee-common-wildfly/src/main/java/dev/langchain4j/cdi/core/integrationtests/ChatModelMock.java
@@ -9,12 +9,19 @@ import dev.langchain4j.model.output.TokenUsage;
 import dev.langchain4j.store.embedding.EmbeddingStore;
 import jakarta.enterprise.context.ApplicationScoped;
 
+/** Mock {@link ChatModel} for Jakarta EE integration testing. */
 @ApplicationScoped
 public class ChatModelMock implements ChatModel {
 
     private final ChatResponse fixedChatResponse;
     private final EmbeddingStore<TextSegment> embeddingStore;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param fixedChatResponse the fixed response to return, or {@code null}
+     * @param embeddingStore the embedding store for response composition
+     */
     public ChatModelMock(ChatResponse fixedChatResponse, EmbeddingStore<TextSegment> embeddingStore) {
         this.fixedChatResponse = fixedChatResponse;
         this.embeddingStore = embeddingStore;
@@ -31,25 +38,51 @@ public class ChatModelMock implements ChatModel {
                 .build();
     }
 
+    /**
+     * Creates a new builder.
+     *
+     * @return a new builder instance
+     */
     public static ChatModelMockBuilder builder() {
         return new ChatModelMockBuilder();
     }
 
+    /** Builder for {@link ChatModelMock}. */
     public static class ChatModelMockBuilder {
+
+        /** Creates a new instance. */
+        public ChatModelMockBuilder() {}
 
         private ChatResponse fixedChatResponse;
         private EmbeddingStore<TextSegment> embeddingStore;
 
+        /**
+         * Sets the fixed chat response.
+         *
+         * @param fixedChatResponse the response to return
+         * @return this builder
+         */
         public ChatModelMockBuilder fixedChatResponse(ChatResponse fixedChatResponse) {
             this.fixedChatResponse = fixedChatResponse;
             return this;
         }
 
+        /**
+         * Sets the embedding store.
+         *
+         * @param embeddingStore the embedding store
+         * @return this builder
+         */
         public ChatModelMockBuilder embeddingStore(EmbeddingStore<TextSegment> embeddingStore) {
             this.embeddingStore = embeddingStore;
             return this;
         }
 
+        /**
+         * Builds the mock.
+         *
+         * @return a new {@link ChatModelMock}
+         */
         public ChatModelMock build() {
             return new ChatModelMock(fixedChatResponse, embeddingStore);
         }

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-jakartaee/langchain4j-cdi-integration-tests-jakartaee-common-wildfly/src/main/java/dev/langchain4j/cdi/core/integrationtests/DummyLLConfig.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-jakartaee/langchain4j-cdi-integration-tests-jakartaee-common-wildfly/src/main/java/dev/langchain4j/cdi/core/integrationtests/DummyLLConfig.java
@@ -9,7 +9,12 @@ import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+/** Dummy {@link LLMConfig} that reads configuration from a properties file. */
 public class DummyLLConfig extends LLMConfig {
+
+    /** Creates a new instance. */
+    public DummyLLConfig() {}
+
     Properties properties = new Properties();
     private static final Logger LOGGER = Logger.getLogger(DummyLLConfig.class.getName());
 

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-jakartaee/langchain4j-cdi-integration-tests-jakartaee-common-wildfly/src/main/java/dev/langchain4j/cdi/core/integrationtests/EmbeddingStoreString.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-jakartaee/langchain4j-cdi-integration-tests-jakartaee-common-wildfly/src/main/java/dev/langchain4j/cdi/core/integrationtests/EmbeddingStoreString.java
@@ -7,8 +7,13 @@ import dev.langchain4j.store.embedding.EmbeddingStore;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
 
+/** No-op {@link EmbeddingStore} of {@link String} for integration testing. */
 @ApplicationScoped
 public class EmbeddingStoreString implements EmbeddingStore<String> {
+
+    /** Creates a new instance. */
+    public EmbeddingStoreString() {}
+
     @Override
     public String add(Embedding embedding) {
         return "";

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-jakartaee/langchain4j-cdi-integration-tests-jakartaee-common-wildfly/src/main/java/dev/langchain4j/cdi/core/integrationtests/EmbeddingStoreTextSegment.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-jakartaee/langchain4j-cdi-integration-tests-jakartaee-common-wildfly/src/main/java/dev/langchain4j/cdi/core/integrationtests/EmbeddingStoreTextSegment.java
@@ -8,8 +8,13 @@ import dev.langchain4j.store.embedding.EmbeddingStore;
 import jakarta.enterprise.context.ApplicationScoped;
 import java.util.List;
 
+/** No-op {@link EmbeddingStore} of {@link TextSegment} for integration testing. */
 @ApplicationScoped
 public class EmbeddingStoreTextSegment implements EmbeddingStore<TextSegment> {
+
+    /** Creates a new instance. */
+    public EmbeddingStoreTextSegment() {}
+
     @Override
     public String add(Embedding embedding) {
         return "";

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-jakartaee/langchain4j-cdi-integration-tests-jakartaee-common-wildfly/src/main/java/dev/langchain4j/cdi/core/integrationtests/JaxRsApplication.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-jakartaee/langchain4j-cdi-integration-tests-jakartaee-common-wildfly/src/main/java/dev/langchain4j/cdi/core/integrationtests/JaxRsApplication.java
@@ -3,5 +3,10 @@ package dev.langchain4j.cdi.core.integrationtests;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 
+/** JAX-RS application definition for integration testing. */
 @ApplicationPath("/")
-public class JaxRsApplication extends Application {}
+public class JaxRsApplication extends Application {
+
+    /** Creates a new instance. */
+    public JaxRsApplication() {}
+}

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/main/java/dev/langchain4j/cdi/core/integrationtests/ChatModelMock.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/main/java/dev/langchain4j/cdi/core/integrationtests/ChatModelMock.java
@@ -7,11 +7,20 @@ import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.output.TokenUsage;
 import jakarta.enterprise.context.ApplicationScoped;
 
+/** Mock {@link ChatModel} for Quarkus integration testing. */
 @ApplicationScoped
 public class ChatModelMock implements ChatModel {
 
+    /** Creates a new instance. */
+    public ChatModelMock() {}
+
     private ChatResponse fixedChatResponse;
 
+    /**
+     * Sets a fixed response to return for all chat requests.
+     *
+     * @param fixedChatResponse the response to return
+     */
     public void setFixedChatResponse(ChatResponse fixedChatResponse) {
         this.fixedChatResponse = fixedChatResponse;
     }
@@ -27,12 +36,26 @@ public class ChatModelMock implements ChatModel {
                 .build();
     }
 
+    /**
+     * Creates a new builder.
+     *
+     * @return a new builder instance
+     */
     public static ChatModelMockBuilder builder() {
         return new ChatModelMockBuilder();
     }
 
+    /** Builder for {@link ChatModelMock}. */
     public static class ChatModelMockBuilder {
 
+        /** Creates a new instance. */
+        public ChatModelMockBuilder() {}
+
+        /**
+         * Builds the mock.
+         *
+         * @return a new {@link ChatModelMock}
+         */
         public ChatModelMock build() {
             return new ChatModelMock();
         }

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/main/java/dev/langchain4j/cdi/core/integrationtests/ExpressionChatAiService.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/main/java/dev/langchain4j/cdi/core/integrationtests/ExpressionChatAiService.java
@@ -4,10 +4,17 @@ import dev.langchain4j.cdi.spi.RegisterAIService;
 import dev.langchain4j.service.SystemMessage;
 import jakarta.enterprise.context.ApplicationScoped;
 
+/** AI chat service using expression-resolved model name for integration testing. */
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(chatModelName = "${test.expression.model}", scope = ApplicationScoped.class)
 public interface ExpressionChatAiService {
 
+    /**
+     * Sends a question to the chat model.
+     *
+     * @param question the user question
+     * @return the model response
+     */
     @SystemMessage("my system message.")
     String chat(String question);
 }

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/main/java/dev/langchain4j/cdi/core/integrationtests/ExpressionChatRestService.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/main/java/dev/langchain4j/cdi/core/integrationtests/ExpressionChatRestService.java
@@ -7,6 +7,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
+/** JAX-RS endpoint for expression-resolved chat integration testing. */
 @Path("/expression-chat")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -15,6 +16,15 @@ public class ExpressionChatRestService {
     @Inject
     ExpressionChatAiService expressionChatAiService;
 
+    /** Creates a new instance. */
+    public ExpressionChatRestService() {}
+
+    /**
+     * Forwards a chat request to the expression-resolved AI service.
+     *
+     * @param chatRequest the user message
+     * @return the AI response
+     */
     @POST
     public String postChat(String chatRequest) {
         return expressionChatAiService.chat(chatRequest);

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/main/java/dev/langchain4j/cdi/core/integrationtests/HumanInTheLoopRestService.java
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-quarkus/src/main/java/dev/langchain4j/cdi/core/integrationtests/HumanInTheLoopRestService.java
@@ -8,6 +8,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 
+/** JAX-RS endpoint for human-in-the-loop agent integration testing. */
 @Path("/hitl-agent")
 @Produces(MediaType.TEXT_PLAIN)
 public class HumanInTheLoopRestService {
@@ -18,12 +19,25 @@ public class HumanInTheLoopRestService {
     @Inject
     HumanInTheLoopEntryMethodAgentService entryMethodAgent;
 
+    /** Creates a new instance. */
+    public HumanInTheLoopRestService() {}
+
+    /**
+     * Returns info about the marker-based HITL agent.
+     *
+     * @return the agent string representation
+     */
     @GET
     @Path("/marker")
     public String markerAgentInfo() {
         return markerAgent.toString();
     }
 
+    /**
+     * Returns info about the entry-method-based HITL agent.
+     *
+     * @return the agent string representation
+     */
     @GET
     @Path("/entry-method")
     public String entryMethodAgentInfo() {

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-build-compatible-ext/src/main/java/dev/langchain4j/cdi/mcp/buildcompatible/McpServerBuildCompatibleExtension.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-build-compatible-ext/src/main/java/dev/langchain4j/cdi/mcp/buildcompatible/McpServerBuildCompatibleExtension.java
@@ -15,7 +15,15 @@ import org.mcp_java.annotations.resources.Resource;
 import org.mcp_java.annotations.resources.ResourceTemplate;
 import org.mcp_java.annotations.tools.Tool;
 
+/**
+ * Build-compatible CDI extension that detects beans annotated with MCP annotations ({@code @Tool}, {@code @Resource},
+ * {@code @ResourceTemplate}, {@code @Prompt}) and synthesizes a {@link McpToolRegistryPopulator} bean to register them
+ * at deployment time.
+ */
 public class McpServerBuildCompatibleExtension implements BuildCompatibleExtension {
+
+    /** Creates a new instance. */
+    public McpServerBuildCompatibleExtension() {}
 
     private static final Logger LOGGER = Logger.getLogger(McpServerBuildCompatibleExtension.class.getName());
     private static final Set<String> detectedToolBeanClassNames = new HashSet<>();
@@ -23,6 +31,12 @@ public class McpServerBuildCompatibleExtension implements BuildCompatibleExtensi
     private static final Set<String> detectedResourceTemplateBeanClassNames = new HashSet<>();
     private static final Set<String> detectedPromptBeanClassNames = new HashSet<>();
 
+    /**
+     * Scans all classes during the enhancement phase and collects those that contain methods annotated with MCP
+     * annotations.
+     *
+     * @param classConfig the class configuration being inspected
+     */
     @SuppressWarnings("unused")
     @Enhancement(types = Object.class, withSubtypes = true)
     public void detectMcpBeans(ClassConfig classConfig) {
@@ -52,6 +66,12 @@ public class McpServerBuildCompatibleExtension implements BuildCompatibleExtensi
         }
     }
 
+    /**
+     * Synthesizes a {@link McpToolRegistryPopulator} bean if any MCP-annotated beans were detected, passing the
+     * collected class names as synthetic bean parameters.
+     *
+     * @param syntheticComponents the synthetic component registrar
+     */
     @SuppressWarnings("unused")
     @Synthesis
     public void registerMcpBeans(SyntheticComponents syntheticComponents) {

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-build-compatible-ext/src/main/java/dev/langchain4j/cdi/mcp/buildcompatible/McpToolRegistryPopulator.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-build-compatible-ext/src/main/java/dev/langchain4j/cdi/mcp/buildcompatible/McpToolRegistryPopulator.java
@@ -1,4 +1,8 @@
 package dev.langchain4j.cdi.mcp.buildcompatible;
 
 /** Marker bean created by the build-compatible extension to trigger tool registration during deployment. */
-public class McpToolRegistryPopulator {}
+public class McpToolRegistryPopulator {
+
+    /** Creates a new instance. */
+    public McpToolRegistryPopulator() {}
+}

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-build-compatible-ext/src/main/java/dev/langchain4j/cdi/mcp/buildcompatible/McpToolRegistryPopulatorCreator.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-build-compatible-ext/src/main/java/dev/langchain4j/cdi/mcp/buildcompatible/McpToolRegistryPopulatorCreator.java
@@ -16,12 +16,27 @@ import org.mcp_java.annotations.resources.Resource;
 import org.mcp_java.annotations.resources.ResourceTemplate;
 import org.mcp_java.annotations.tools.Tool;
 
+/**
+ * Synthetic bean creator that instantiates a {@link McpToolRegistryPopulator} and registers all detected MCP tool,
+ * resource, resource template, and prompt descriptors into their respective registries.
+ */
 public class McpToolRegistryPopulatorCreator implements SyntheticBeanCreator<McpToolRegistryPopulator> {
 
+    /** Creates a new instance. */
+    public McpToolRegistryPopulatorCreator() {}
+
     private static final Logger LOGGER = Logger.getLogger(McpToolRegistryPopulatorCreator.class.getName());
+
+    /** Synthetic bean parameter name for the array of tool bean class names. */
     public static final String PARAM_TOOL_BEAN_CLASSES = "toolBeanClasses";
+
+    /** Synthetic bean parameter name for the array of resource bean class names. */
     public static final String PARAM_RESOURCE_BEAN_CLASSES = "resourceBeanClasses";
+
+    /** Synthetic bean parameter name for the array of resource template bean class names. */
     public static final String PARAM_RESOURCE_TEMPLATE_BEAN_CLASSES = "resourceTemplateBeanClasses";
+
+    /** Synthetic bean parameter name for the array of prompt bean class names. */
     public static final String PARAM_PROMPT_BEAN_CLASSES = "promptBeanClasses";
 
     @Override

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-example-helidon/src/main/java/dev/langchain4j/cdi/examples/mcp/HelloMcpTools.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-example-helidon/src/main/java/dev/langchain4j/cdi/examples/mcp/HelloMcpTools.java
@@ -7,15 +7,30 @@ import org.mcp_java.annotations.resources.Resource;
 import org.mcp_java.annotations.tools.Tool;
 import org.mcp_java.annotations.tools.ToolArg;
 
+/** Example CDI bean exposing MCP tools, resources, and prompts for the Helidon MCP server demo. */
 @SuppressWarnings("unused")
 @ApplicationScoped
 public class HelloMcpTools {
 
+    /** Creates a new HelloMcpTools. */
+    public HelloMcpTools() {}
+
+    /**
+     * Greets a person by name.
+     *
+     * @param name the name of the person to greet
+     * @return a greeting message
+     */
     @Tool(description = "Say hello to someone by name")
     public String hello(@ToolArg(description = "The name of the person to greet") String name) {
         return "Hello, " + name + "!";
     }
 
+    /**
+     * Returns the current server configuration as JSON.
+     *
+     * @return the server configuration in JSON format
+     */
     @Resource(
             uri = "config://server",
             name = "Server Config",
@@ -25,6 +40,12 @@ public class HelloMcpTools {
         return "{\"name\":\"helidon-mcp-server\",\"version\":\"1.0\"}";
     }
 
+    /**
+     * Generates a greeting prompt for a person.
+     *
+     * @param name the name of the person to greet
+     * @return a prompt string requesting a creative greeting
+     */
     @Prompt(description = "Generate a greeting message for a person")
     public String greetingPrompt(@PromptArg(description = "The person's name") String name) {
         return "Write a warm and friendly greeting for " + name + ". Be creative and personal.";

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/AbstractMcpIntegrationTest.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/AbstractMcpIntegrationTest.java
@@ -16,11 +16,21 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
+/** Base class for MCP server integration tests. */
 @SuppressWarnings("java:S112")
 public abstract class AbstractMcpIntegrationTest {
 
+    /** JSON key for the {@code content} array in MCP responses. */
     public static final String CONTENT = "content";
 
+    /** Creates a new instance. */
+    public AbstractMcpIntegrationTest() {}
+
+    /**
+     * Returns the HTTP transport used to communicate with the MCP endpoint.
+     *
+     * @return the transport
+     */
     protected abstract McpHttpTransport transport();
 
     // --- Tools via MCP Client ---
@@ -345,6 +355,11 @@ public abstract class AbstractMcpIntegrationTest {
 
     // --- Helpers ---
 
+    /**
+     * Sends an {@code initialize} request and returns the session id.
+     *
+     * @return the MCP session id
+     */
     protected String initializeSession() {
         McpHttpResponse response = transport().post("/mcp", McpTestRequests.initializeRequest(1), Map.of());
         JsonRpcAssertions.assertJsonRpcSuccess(response, 1);
@@ -353,10 +368,22 @@ public abstract class AbstractMcpIntegrationTest {
         return sessionId;
     }
 
+    /**
+     * Posts a JSON-RPC body to the MCP endpoint using the given session.
+     *
+     * @param sessionId the MCP session id
+     * @param body the JSON-RPC request body
+     * @return the HTTP response
+     */
     protected McpHttpResponse postMcp(String sessionId, String body) {
         return transport().post("/mcp", body, Map.of(MCP_SESSION_ID, sessionId));
     }
 
+    /**
+     * Builds a new {@link McpClient} connected to the test MCP endpoint.
+     *
+     * @return a new MCP client
+     */
     protected McpClient buildClient() {
         return DefaultMcpClient.builder()
                 .transport(StreamableHttpMcpTransport.builder()

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/ArquillianDeploymentHelper.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/ArquillianDeploymentHelper.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.function.BiPredicate;
 
+/** Utility for locating build artifacts used in Arquillian deployments. */
 public class ArquillianDeploymentHelper {
 
     private ArquillianDeploymentHelper() {}
@@ -15,6 +16,11 @@ public class ArquillianDeploymentHelper {
     /**
      * Finds the first JAR in {@code folder} whose name starts with {@code prefix}. Throws {@link IllegalStateException}
      * if no match is found — run {@code mvn install} on the parent modules first.
+     *
+     * @param folder the directory to search in
+     * @param prefix the JAR filename prefix to match
+     * @return the matching JAR file
+     * @throws IOException if the directory cannot be read
      */
     public static File findBuildFile(String folder, String prefix) throws IOException {
         return Files.find(

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/ConfigResource.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/ConfigResource.java
@@ -3,9 +3,18 @@ package dev.langchain4j.cdi.mcp.integrationtests;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.mcp_java.annotations.resources.Resource;
 
+/** MCP resource provider exposing application configuration and status. */
 @ApplicationScoped
 public class ConfigResource {
 
+    /** Creates a new instance. */
+    public ConfigResource() {}
+
+    /**
+     * Returns the application configuration as JSON.
+     *
+     * @return the configuration JSON string
+     */
     @Resource(
             uri = "config://app",
             name = "Application Config",
@@ -15,6 +24,11 @@ public class ConfigResource {
         return "{\"version\":\"1.0\",\"env\":\"test\"}";
     }
 
+    /**
+     * Returns the server status.
+     *
+     * @return the status string
+     */
     @Resource(uri = "data://status", name = "Status", description = "Server status")
     public String getStatus() {
         return "running";

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/GreetingTool.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/GreetingTool.java
@@ -4,9 +4,20 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.mcp_java.annotations.tools.Tool;
 import org.mcp_java.annotations.tools.ToolArg;
 
+/** MCP tool that generates greeting messages. */
 @ApplicationScoped
 public class GreetingTool {
 
+    /** Creates a new instance. */
+    public GreetingTool() {}
+
+    /**
+     * Greets someone by name with an optional prefix.
+     *
+     * @param name the person's name
+     * @param prefix optional greeting prefix, defaults to "Hello"
+     * @return the greeting message
+     */
     @Tool(description = "Greet someone by name")
     public String greet(
             @ToolArg(description = "The person's name") String name,

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/JaxRsApplication.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/JaxRsApplication.java
@@ -3,5 +3,10 @@ package dev.langchain4j.cdi.mcp.integrationtests;
 import jakarta.ws.rs.ApplicationPath;
 import jakarta.ws.rs.core.Application;
 
+/** JAX-RS application definition for MCP integration testing. */
 @ApplicationPath("/")
-public class JaxRsApplication extends Application {}
+public class JaxRsApplication extends Application {
+
+    /** Creates a new instance. */
+    public JaxRsApplication() {}
+}

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/JdkHttpClientTransport.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/JdkHttpClientTransport.java
@@ -9,10 +9,17 @@ import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
 
+/** {@link McpHttpTransport} backed by the JDK {@link java.net.http.HttpClient}. */
 public class JdkHttpClientTransport implements McpHttpTransport {
 
+    /** The normalized base URL (no trailing slash). */
     private final String baseUrl;
 
+    /**
+     * Creates a new transport for the given base URL.
+     *
+     * @param baseUrl the base URL of the MCP endpoint
+     */
     public JdkHttpClientTransport(String baseUrl) {
         this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/JsonRpcAssertions.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/JsonRpcAssertions.java
@@ -8,13 +8,23 @@ import jakarta.json.JsonObject;
 import jakarta.json.JsonReader;
 import java.io.StringReader;
 
+/** Assertion helpers for JSON-RPC responses in MCP integration tests. */
 public final class JsonRpcAssertions {
 
+    /** JSON field name for the error object. */
     static final String FIELD_ERROR = "error";
+
+    /** JSON field name for the result object. */
     static final String FIELD_RESULT = "result";
 
     private JsonRpcAssertions() {}
 
+    /**
+     * Parses the response body as a {@link JsonObject}, asserting a 200 status.
+     *
+     * @param response the HTTP response
+     * @return the parsed JSON object
+     */
     public static JsonObject parseJson(McpHttpResponse response) {
         assertThat(response.statusCode()).isEqualTo(200);
         assertThat(response.body()).isNotNull().isNotBlank();
@@ -23,6 +33,13 @@ public final class JsonRpcAssertions {
         }
     }
 
+    /**
+     * Asserts a successful JSON-RPC response and returns its {@code result} object.
+     *
+     * @param response the HTTP response
+     * @param expectedId the expected JSON-RPC id
+     * @return the {@code result} JSON object
+     */
     public static JsonObject assertJsonRpcSuccess(McpHttpResponse response, Object expectedId) {
         JsonObject json = parseJson(response);
         assertThat(json.getString("jsonrpc")).isEqualTo("2.0");
@@ -36,6 +53,15 @@ public final class JsonRpcAssertions {
         return json.getJsonObject(FIELD_RESULT);
     }
 
+    /**
+     * Asserts a JSON-RPC error response and returns its {@code error} object.
+     *
+     * @param response the HTTP response
+     * @param expectedId the expected JSON-RPC id
+     * @param expectedErrorCode the expected error code
+     * @param expectedMessageSubstring substring expected in the error message
+     * @return the {@code error} JSON object
+     */
     public static JsonObject assertJsonRpcError(
             McpHttpResponse response, Object expectedId, int expectedErrorCode, String expectedMessageSubstring) {
         JsonObject json = parseJson(response);
@@ -56,6 +82,11 @@ public final class JsonRpcAssertions {
         return error;
     }
 
+    /**
+     * Asserts that a notification was accepted (HTTP 200).
+     *
+     * @param response the HTTP response
+     */
     public static void assertNotificationAccepted(McpHttpResponse response) {
         assertThat(response.statusCode()).isEqualTo(200);
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/McpHttpResponse.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/McpHttpResponse.java
@@ -2,9 +2,21 @@ package dev.langchain4j.cdi.mcp.integrationtests;
 
 import java.util.Map;
 
+/**
+ * HTTP response from an MCP endpoint.
+ *
+ * @param statusCode the HTTP status code
+ * @param body the response body
+ * @param headers the response headers
+ */
 public record McpHttpResponse(int statusCode, String body, Map<String, String> headers) {
 
-    /** Returns the value of the given header, trying an exact match first then a case-insensitive lookup. */
+    /**
+     * Returns the value of the given header, trying an exact match first then a case-insensitive lookup.
+     *
+     * @param name the header name
+     * @return the header value, or {@code null} if not found
+     */
     public String header(String name) {
         String value = headers.get(name);
         if (value != null) {

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/McpHttpTransport.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/McpHttpTransport.java
@@ -2,11 +2,32 @@ package dev.langchain4j.cdi.mcp.integrationtests;
 
 import java.util.Map;
 
+/** HTTP transport abstraction for sending requests to an MCP endpoint. */
 public interface McpHttpTransport {
 
+    /**
+     * Sends a POST request.
+     *
+     * @param path the request path
+     * @param body the request body
+     * @param headers additional headers
+     * @return the response
+     */
     McpHttpResponse post(String path, String body, Map<String, String> headers);
 
+    /**
+     * Sends a DELETE request.
+     *
+     * @param path the request path
+     * @param headers additional headers
+     * @return the response
+     */
     McpHttpResponse delete(String path, Map<String, String> headers);
 
+    /**
+     * Returns the base URL of the MCP endpoint.
+     *
+     * @return the base URL
+     */
     String baseUrl();
 }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/McpTestConstants.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/McpTestConstants.java
@@ -1,12 +1,24 @@
 package dev.langchain4j.cdi.mcp.integrationtests;
 
+/** Shared constants for MCP integration tests. */
 public final class McpTestConstants {
 
+    /** Tool name for the weather tool. */
     public static final String GET_WEATHER = "getWeather";
+
+    /** Tool name for the greeting tool. */
     public static final String GREET = "greet";
+
+    /** HTTP header name for the MCP session identifier. */
     public static final String MCP_SESSION_ID = "Mcp-Session-Id";
+
+    /** URI of the application configuration resource. */
     public static final String CONFIG_APP = "config://app";
+
+    /** JSON key for the resources array. */
     public static final String RESOURCES = "resources";
+
+    /** Prompt name for the summarize prompt. */
     public static final String SUMMARIZE = "summarize";
 
     private McpTestConstants() {}

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/McpTestRequests.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/McpTestRequests.java
@@ -1,31 +1,63 @@
 package dev.langchain4j.cdi.mcp.integrationtests;
 
+/** Factory for JSON-RPC request bodies used in MCP integration tests. */
 public final class McpTestRequests {
 
     private McpTestRequests() {}
 
     // --- Lifecycle ---
 
+    /**
+     * Builds an {@code initialize} request.
+     *
+     * @param id the JSON-RPC request id
+     * @return the request body
+     */
     public static String initializeRequest(Object id) {
         return "{\"jsonrpc\":\"2.0\",\"id\":%s,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"test-client\",\"version\":\"1.0\"}}}"
                 .formatted(formatId(id));
     }
 
+    /**
+     * Builds an {@code initialized} notification.
+     *
+     * @return the notification body
+     */
     @SuppressWarnings("java:S3400")
     public static String initializedNotification() {
         return "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\",\"params\":{}}";
     }
 
+    /**
+     * Builds a {@code ping} request.
+     *
+     * @param id the JSON-RPC request id
+     * @return the request body
+     */
     public static String pingRequest(Object id) {
         return "{\"jsonrpc\":\"2.0\",\"id\":%s,\"method\":\"ping\",\"params\":{}}".formatted(formatId(id));
     }
 
     // --- Tools ---
 
+    /**
+     * Builds a {@code tools/list} request.
+     *
+     * @param id the JSON-RPC request id
+     * @return the request body
+     */
     public static String toolsListRequest(Object id) {
         return "{\"jsonrpc\":\"2.0\",\"id\":%s,\"method\":\"tools/list\",\"params\":{}}".formatted(formatId(id));
     }
 
+    /**
+     * Builds a {@code tools/call} request.
+     *
+     * @param id the JSON-RPC request id
+     * @param toolName the tool to call
+     * @param argsJson the tool arguments as JSON
+     * @return the request body
+     */
     public static String toolsCallRequest(Object id, String toolName, String argsJson) {
         return "{\"jsonrpc\":\"2.0\",\"id\":%s,\"method\":\"tools/call\",\"params\":{\"name\":\"%s\",\"arguments\":%s}}"
                 .formatted(formatId(id), toolName, argsJson);
@@ -33,25 +65,58 @@ public final class McpTestRequests {
 
     // --- Resources ---
 
+    /**
+     * Builds a {@code resources/list} request.
+     *
+     * @param id the JSON-RPC request id
+     * @return the request body
+     */
     public static String resourcesListRequest(Object id) {
         return "{\"jsonrpc\":\"2.0\",\"id\":%s,\"method\":\"resources/list\",\"params\":{}}".formatted(formatId(id));
     }
 
+    /**
+     * Builds a {@code resources/read} request.
+     *
+     * @param id the JSON-RPC request id
+     * @param uri the resource URI
+     * @return the request body
+     */
     public static String resourcesReadRequest(Object id, String uri) {
         return "{\"jsonrpc\":\"2.0\",\"id\":%s,\"method\":\"resources/read\",\"params\":{\"uri\":\"%s\"}}"
                 .formatted(formatId(id), uri);
     }
 
+    /**
+     * Builds a {@code resources/subscribe} request.
+     *
+     * @param id the JSON-RPC request id
+     * @param uri the resource URI
+     * @return the request body
+     */
     public static String resourcesSubscribeRequest(Object id, String uri) {
         return "{\"jsonrpc\":\"2.0\",\"id\":%s,\"method\":\"resources/subscribe\",\"params\":{\"uri\":\"%s\"}}"
                 .formatted(formatId(id), uri);
     }
 
+    /**
+     * Builds a {@code resources/unsubscribe} request.
+     *
+     * @param id the JSON-RPC request id
+     * @param uri the resource URI
+     * @return the request body
+     */
     public static String resourcesUnsubscribeRequest(Object id, String uri) {
         return "{\"jsonrpc\":\"2.0\",\"id\":%s,\"method\":\"resources/unsubscribe\",\"params\":{\"uri\":\"%s\"}}"
                 .formatted(formatId(id), uri);
     }
 
+    /**
+     * Builds a {@code resources/templates/list} request.
+     *
+     * @param id the JSON-RPC request id
+     * @return the request body
+     */
     public static String resourcesTemplatesListRequest(Object id) {
         return "{\"jsonrpc\":\"2.0\",\"id\":%s,\"method\":\"resources/templates/list\",\"params\":{}}"
                 .formatted(formatId(id));
@@ -59,15 +124,36 @@ public final class McpTestRequests {
 
     // --- Prompts ---
 
+    /**
+     * Builds a {@code prompts/list} request.
+     *
+     * @param id the JSON-RPC request id
+     * @return the request body
+     */
     public static String promptsListRequest(Object id) {
         return "{\"jsonrpc\":\"2.0\",\"id\":%s,\"method\":\"prompts/list\",\"params\":{}}".formatted(formatId(id));
     }
 
+    /**
+     * Builds a {@code prompts/get} request with arguments.
+     *
+     * @param id the JSON-RPC request id
+     * @param name the prompt name
+     * @param argsJson the prompt arguments as JSON
+     * @return the request body
+     */
     public static String promptsGetRequest(Object id, String name, String argsJson) {
         return "{\"jsonrpc\":\"2.0\",\"id\":%s,\"method\":\"prompts/get\",\"params\":{\"name\":\"%s\",\"arguments\":%s}}"
                 .formatted(formatId(id), name, argsJson);
     }
 
+    /**
+     * Builds a {@code prompts/get} request without arguments.
+     *
+     * @param id the JSON-RPC request id
+     * @param name the prompt name
+     * @return the request body
+     */
     public static String promptsGetRequest(Object id, String name) {
         return "{\"jsonrpc\":\"2.0\",\"id\":%s,\"method\":\"prompts/get\",\"params\":{\"name\":\"%s\"}}"
                 .formatted(formatId(id), name);
@@ -75,6 +161,16 @@ public final class McpTestRequests {
 
     // --- Completion ---
 
+    /**
+     * Builds a {@code completion/complete} request.
+     *
+     * @param id the JSON-RPC request id
+     * @param refType the reference type
+     * @param refName the reference name
+     * @param argName the argument name
+     * @param argValue the argument value
+     * @return the request body
+     */
     public static String completionCompleteRequest(
             Object id, String refType, String refName, String argName, String argValue) {
         return "{\"jsonrpc\":\"2.0\",\"id\":%s,\"method\":\"completion/complete\",\"params\":{\"ref\":{\"type\":\"%s\",\"name\":\"%s\"},\"argument\":{\"name\":\"%s\",\"value\":\"%s\"}}}"
@@ -83,6 +179,13 @@ public final class McpTestRequests {
 
     // --- Logging ---
 
+    /**
+     * Builds a {@code logging/setLevel} request.
+     *
+     * @param id the JSON-RPC request id
+     * @param level the log level to set
+     * @return the request body
+     */
     public static String loggingSetLevelRequest(Object id, String level) {
         return "{\"jsonrpc\":\"2.0\",\"id\":%s,\"method\":\"logging/setLevel\",\"params\":{\"level\":\"%s\"}}"
                 .formatted(formatId(id), level);
@@ -90,11 +193,23 @@ public final class McpTestRequests {
 
     // --- Notifications ---
 
+    /**
+     * Builds a {@code notifications/cancelled} notification.
+     *
+     * @param requestId the id of the request to cancel
+     * @param reason the cancellation reason
+     * @return the notification body
+     */
     public static String cancelledNotification(String requestId, String reason) {
         return "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/cancelled\",\"params\":{\"requestId\":\"%s\",\"reason\":\"%s\"}}"
                 .formatted(requestId, reason);
     }
 
+    /**
+     * Builds a {@code notifications/roots/list_changed} notification.
+     *
+     * @return the notification body
+     */
     @SuppressWarnings("java:S3400")
     public static String rootsListChangedNotification() {
         return "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/roots/list_changed\",\"params\":{}}";
@@ -102,10 +217,24 @@ public final class McpTestRequests {
 
     // --- Unknown / Error scenarios ---
 
+    /**
+     * Builds a request with an unknown method name.
+     *
+     * @param id the JSON-RPC request id
+     * @param method the method name
+     * @return the request body
+     */
     public static String unknownMethodRequest(Object id, String method) {
         return "{\"jsonrpc\":\"2.0\",\"id\":%s,\"method\":\"%s\",\"params\":{}}".formatted(formatId(id), method);
     }
 
+    /**
+     * Builds a client-initiated JSON-RPC response (e.g. for roots).
+     *
+     * @param id the JSON-RPC id matching the server's request
+     * @param resultJson the result payload as JSON
+     * @return the response body
+     */
     public static String clientJsonRpcResponse(Object id, String resultJson) {
         return "{\"jsonrpc\":\"2.0\",\"id\":%s,\"result\":%s}".formatted(formatId(id), resultJson);
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/SummarizePrompt.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/SummarizePrompt.java
@@ -4,9 +4,19 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.mcp_java.annotations.prompts.Prompt;
 import org.mcp_java.annotations.prompts.PromptArg;
 
+/** MCP prompt that generates a summarization request. */
 @ApplicationScoped
 public class SummarizePrompt {
 
+    /** Creates a new instance. */
+    public SummarizePrompt() {}
+
+    /**
+     * Produces a summarization prompt for the given text.
+     *
+     * @param text the text to summarize
+     * @return the summarization prompt
+     */
     @Prompt(description = "Summarize the given text")
     public String summarize(@PromptArg(description = "The text to summarize") String text) {
         return "Please summarize the following text:\n\n" + text;

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/WeatherTool.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-common/src/main/java/dev/langchain4j/cdi/mcp/integrationtests/WeatherTool.java
@@ -4,9 +4,20 @@ import jakarta.enterprise.context.ApplicationScoped;
 import org.mcp_java.annotations.tools.Tool;
 import org.mcp_java.annotations.tools.ToolArg;
 
+/** MCP tool that returns weather information for a city. */
 @ApplicationScoped
 public class WeatherTool {
 
+    /** Creates a new instance. */
+    public WeatherTool() {}
+
+    /**
+     * Returns a fixed weather string for the given city.
+     *
+     * @param city the city name
+     * @param unit the temperature unit (celsius or fahrenheit)
+     * @return the weather description
+     */
     @Tool(description = "Get the current weather for a given city")
     public String getWeather(
             @ToolArg(description = "The city name") String city,

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-portable-ext/src/main/java/dev/langchain4j/cdi/mcp/portableextension/McpServerPortableExtension.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-portable-ext/src/main/java/dev/langchain4j/cdi/mcp/portableextension/McpServerPortableExtension.java
@@ -22,10 +22,18 @@ import org.mcp_java.annotations.resources.Resource;
 import org.mcp_java.annotations.resources.ResourceTemplate;
 import org.mcp_java.annotations.tools.Tool;
 
+/**
+ * CDI portable extension that discovers beans annotated with MCP annotations ({@code @Tool}, {@code @Resource},
+ * {@code @ResourceTemplate}, {@code @Prompt}) and registers them with the corresponding MCP registries after deployment
+ * validation.
+ */
 public class McpServerPortableExtension implements Extension {
 
     private static final Logger LOGGER = Logger.getLogger(McpServerPortableExtension.class.getName());
     private final List<McpToolCandidate> candidates = new ArrayList<>();
+
+    /** Creates a new {@code McpServerPortableExtension}. */
+    public McpServerPortableExtension() {}
 
     <T> void onProcessManagedBean(@Observes ProcessManagedBean<T> pmb) {
         Class<?> beanClass = pmb.getAnnotatedBeanClass().getJavaClass();

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/CdiCancellation.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/CdiCancellation.java
@@ -9,6 +9,11 @@ public class CdiCancellation implements Cancellation {
 
     private final AtomicBoolean cancelledFlag;
 
+    /**
+     * Creates a new cancellation check backed by the given flag.
+     *
+     * @param cancelledFlag the flag indicating whether the request has been cancelled
+     */
     public CdiCancellation(AtomicBoolean cancelledFlag) {
         this.cancelledFlag = cancelledFlag;
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/CdiElicitation.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/CdiElicitation.java
@@ -12,6 +12,13 @@ public class CdiElicitation implements Elicitation {
     private final McpElicitationManager elicitationManager;
     private final String sessionId;
 
+    /**
+     * Creates a new elicitation wrapper.
+     *
+     * @param session the MCP session
+     * @param elicitationManager the elicitation manager
+     * @param sessionId the session identifier
+     */
     public CdiElicitation(McpSession session, McpElicitationManager elicitationManager, String sessionId) {
         this.session = session;
         this.elicitationManager = elicitationManager;

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/CdiMcpConnection.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/CdiMcpConnection.java
@@ -13,6 +13,12 @@ public class CdiMcpConnection implements McpConnection {
     private final McpSession session;
     private final McpLogger mcpLogger;
 
+    /**
+     * Creates a new MCP connection wrapper.
+     *
+     * @param session the MCP session
+     * @param mcpLogger the MCP logger
+     */
     public CdiMcpConnection(McpSession session, McpLogger mcpLogger) {
         this.session = session;
         this.mcpLogger = mcpLogger;

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/CdiMcpLog.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/CdiMcpLog.java
@@ -10,6 +10,12 @@ public class CdiMcpLog implements McpLog {
     private final McpLogger mcpLogger;
     private final String loggerName;
 
+    /**
+     * Creates a new MCP log wrapper.
+     *
+     * @param mcpLogger the internal MCP logger
+     * @param loggerName the logger name used for log entries
+     */
     public CdiMcpLog(McpLogger mcpLogger, String loggerName) {
         this.mcpLogger = mcpLogger;
         this.loggerName = loggerName;

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/CdiProgress.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/CdiProgress.java
@@ -13,6 +13,12 @@ public class CdiProgress implements Progress {
     private final Object rawToken;
     private final McpProgressReporter progressReporter;
 
+    /**
+     * Creates a new progress wrapper.
+     *
+     * @param rawToken the raw progress token, or {@code null} if no token was provided
+     * @param progressReporter the progress reporter
+     */
     public CdiProgress(Object rawToken, McpProgressReporter progressReporter) {
         this.rawToken = rawToken;
         this.progressReporter = progressReporter;

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/CdiRoots.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/CdiRoots.java
@@ -13,6 +13,13 @@ public class CdiRoots implements Roots {
     private final McpRootsManager rootsManager;
     private final String sessionId;
 
+    /**
+     * Creates a new roots wrapper.
+     *
+     * @param session the MCP session
+     * @param rootsManager the roots manager
+     * @param sessionId the session identifier
+     */
     public CdiRoots(McpSession session, McpRootsManager rootsManager, String sessionId) {
         this.session = session;
         this.rootsManager = rootsManager;

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/CdiSampling.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/CdiSampling.java
@@ -12,6 +12,13 @@ public class CdiSampling implements Sampling {
     private final McpSamplingManager samplingManager;
     private final String sessionId;
 
+    /**
+     * Creates a new sampling wrapper.
+     *
+     * @param session the MCP session
+     * @param samplingManager the sampling manager
+     * @param sessionId the session identifier
+     */
     public CdiSampling(McpSession session, McpSamplingManager samplingManager, String sessionId) {
         this.session = session;
         this.samplingManager = samplingManager;

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/McpApiFactory.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/McpApiFactory.java
@@ -23,6 +23,9 @@ import org.mcp_java.server.Sampling;
 @ApplicationScoped
 public class McpApiFactory {
 
+    /** CDI-required default constructor. */
+    public McpApiFactory() {}
+
     @Inject
     McpLogger mcpLogger;
 

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/McpFrameworkTypes.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/api/McpFrameworkTypes.java
@@ -27,6 +27,12 @@ public final class McpFrameworkTypes {
 
     private McpFrameworkTypes() {}
 
+    /**
+     * Returns {@code true} if the given type is a recognized MCP framework type.
+     *
+     * @param type the class to check
+     * @return {@code true} if the type is an MCP framework type
+     */
     public static boolean isFrameworkType(Class<?> type) {
         return FRAMEWORK_TYPES.contains(type);
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/error/McpErrorCode.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/error/McpErrorCode.java
@@ -1,12 +1,20 @@
 package dev.langchain4j.cdi.mcp.server.error;
 
+/** JSON-RPC 2.0 error codes used in MCP protocol responses. */
 public enum McpErrorCode {
+    /** The request payload could not be parsed as valid JSON. */
     PARSE_ERROR(-32700),
+    /** The request is not a valid JSON-RPC 2.0 request. */
     INVALID_REQUEST(-32600),
+    /** The requested method does not exist or is not available. */
     METHOD_NOT_FOUND(-32601),
+    /** Invalid method parameters were supplied. */
     INVALID_PARAMS(-32602),
+    /** An internal server error occurred during processing. */
     INTERNAL_ERROR(-32603),
+    /** The referenced MCP session was not found or has expired. */
     SESSION_NOT_FOUND(-32001),
+    /** The requested tool was not found in the registry. */
     TOOL_NOT_FOUND(-32002);
 
     private final int code;
@@ -15,6 +23,11 @@ public enum McpErrorCode {
         this.code = code;
     }
 
+    /**
+     * Returns the numeric JSON-RPC error code.
+     *
+     * @return the error code
+     */
     public int getCode() {
         return code;
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/error/McpException.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/error/McpException.java
@@ -1,20 +1,41 @@
 package dev.langchain4j.cdi.mcp.server.error;
 
+/** Runtime exception carrying a JSON-RPC error code and the originating request ID. */
 public class McpException extends RuntimeException {
 
+    /** The JSON-RPC request ID that triggered the error. */
     private final Object requestId;
+
+    /** The MCP error code describing the failure category. */
     private final McpErrorCode errorCode;
 
+    /**
+     * Creates an MCP exception with the given request context and message.
+     *
+     * @param requestId the JSON-RPC request ID that triggered the error
+     * @param errorCode the MCP error code describing the failure
+     * @param message a human-readable error description
+     */
     public McpException(Object requestId, McpErrorCode errorCode, String message) {
         super(message);
         this.requestId = requestId;
         this.errorCode = errorCode;
     }
 
+    /**
+     * Returns the JSON-RPC request ID associated with this error.
+     *
+     * @return the request ID
+     */
     public Object getRequestId() {
         return requestId;
     }
 
+    /**
+     * Returns the MCP error code describing the failure.
+     *
+     * @return the error code
+     */
     public McpErrorCode getErrorCode() {
         return errorCode;
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/error/McpSessionException.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/error/McpSessionException.java
@@ -1,7 +1,14 @@
 package dev.langchain4j.cdi.mcp.server.error;
 
+/** Exception thrown when an MCP session cannot be found or has expired. */
 public class McpSessionException extends McpException {
 
+    /**
+     * Creates a session exception with the given request ID and message.
+     *
+     * @param requestId the JSON-RPC request ID that triggered the error
+     * @param message a human-readable description of the session error
+     */
     public McpSessionException(Object requestId, String message) {
         super(requestId, McpErrorCode.SESSION_NOT_FOUND, message);
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/error/McpToolNotFoundException.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/error/McpToolNotFoundException.java
@@ -1,7 +1,14 @@
 package dev.langchain4j.cdi.mcp.server.error;
 
+/** Exception thrown when a requested MCP tool cannot be found in the registry. */
 public class McpToolNotFoundException extends McpException {
 
+    /**
+     * Creates a tool-not-found exception for the given tool name.
+     *
+     * @param requestId the JSON-RPC request ID that triggered the error
+     * @param toolName the name of the tool that was not found
+     */
     public McpToolNotFoundException(Object requestId, String toolName) {
         super(requestId, McpErrorCode.TOOL_NOT_FOUND, "Tool not found: " + toolName);
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/logging/McpLogLevel.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/logging/McpLogLevel.java
@@ -2,12 +2,20 @@ package dev.langchain4j.cdi.mcp.server.logging;
 
 /** MCP log levels as defined by the MCP specification, ordered from least to most severe. */
 public enum McpLogLevel {
+    /** Detailed debugging information. */
     debug,
+    /** Informational messages. */
     info,
+    /** Normal but noteworthy conditions. */
     notice,
+    /** Warning conditions that may require attention. */
     warning,
+    /** Error conditions. */
     error,
+    /** Critical conditions requiring immediate action. */
     critical,
+    /** Action must be taken immediately. */
     alert,
+    /** System is unusable. */
     emergency
 }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/logging/McpLogger.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/logging/McpLogger.java
@@ -9,35 +9,79 @@ import java.util.Map;
 @ApplicationScoped
 public class McpLogger {
 
+    /** CDI-required default constructor. */
+    public McpLogger() {}
+
     @Inject
     McpNotificationBroadcaster broadcaster;
 
     private volatile McpLogLevel minimumLevel = McpLogLevel.debug;
 
+    /**
+     * Sets the minimum log level; messages below this level are discarded.
+     *
+     * @param level the minimum level to broadcast
+     */
     public void setMinimumLevel(McpLogLevel level) {
         this.minimumLevel = level;
     }
 
+    /**
+     * Returns the current minimum log level.
+     *
+     * @return the minimum level
+     */
     public McpLogLevel getMinimumLevel() {
         return minimumLevel;
     }
 
+    /**
+     * Logs a message at {@link McpLogLevel#debug} level.
+     *
+     * @param loggerName the logger name included in the notification
+     * @param message the log message
+     */
     public void debug(String loggerName, String message) {
         log(McpLogLevel.debug, loggerName, message);
     }
 
+    /**
+     * Logs a message at {@link McpLogLevel#info} level.
+     *
+     * @param loggerName the logger name included in the notification
+     * @param message the log message
+     */
     public void info(String loggerName, String message) {
         log(McpLogLevel.info, loggerName, message);
     }
 
+    /**
+     * Logs a message at {@link McpLogLevel#warning} level.
+     *
+     * @param loggerName the logger name included in the notification
+     * @param message the log message
+     */
     public void warning(String loggerName, String message) {
         log(McpLogLevel.warning, loggerName, message);
     }
 
+    /**
+     * Logs a message at {@link McpLogLevel#error} level.
+     *
+     * @param loggerName the logger name included in the notification
+     * @param message the log message
+     */
     public void error(String loggerName, String message) {
         log(McpLogLevel.error, loggerName, message);
     }
 
+    /**
+     * Logs a message at the given level, broadcasting it to all connected MCP clients.
+     *
+     * @param level the log level
+     * @param loggerName the logger name included in the notification
+     * @param message the log message
+     */
     public void log(McpLogLevel level, String loggerName, String message) {
         if (level.ordinal() < minimumLevel.ordinal()) {
             return;

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/protocol/JsonRpcError.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/protocol/JsonRpcError.java
@@ -1,29 +1,57 @@
 package dev.langchain4j.cdi.mcp.server.protocol;
 
+/** Represents a JSON-RPC 2.0 error object. */
 public class JsonRpcError {
 
     private int code;
     private String message;
 
+    /** Default constructor for JSON-B deserialization. */
     public JsonRpcError() {}
 
+    /**
+     * Creates an error with the given code and message.
+     *
+     * @param code the error code
+     * @param message the error message
+     */
     public JsonRpcError(int code, String message) {
         this.code = code;
         this.message = message;
     }
 
+    /**
+     * Returns the error code.
+     *
+     * @return the error code
+     */
     public int getCode() {
         return code;
     }
 
+    /**
+     * Sets the error code.
+     *
+     * @param code the error code
+     */
     public void setCode(int code) {
         this.code = code;
     }
 
+    /**
+     * Returns the error message.
+     *
+     * @return the error message
+     */
     public String getMessage() {
         return message;
     }
 
+    /**
+     * Sets the error message.
+     *
+     * @param message the error message
+     */
     public void setMessage(String message) {
         this.message = message;
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/protocol/JsonRpcNotification.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/protocol/JsonRpcNotification.java
@@ -1,40 +1,88 @@
 package dev.langchain4j.cdi.mcp.server.protocol;
 
+/**
+ * A JSON-RPC 2.0 notification (a request without an {@code id} that expects no response). Provides factory methods for
+ * standard MCP server-to-client notifications.
+ */
 public class JsonRpcNotification {
 
     private String jsonrpc = "2.0";
     private String method;
 
+    /** Default constructor for deserialization. */
     public JsonRpcNotification() {}
 
+    /**
+     * Creates a notification with the given method name.
+     *
+     * @param method the JSON-RPC method name
+     */
     public JsonRpcNotification(String method) {
         this.method = method;
     }
 
     private Object params;
 
+    /**
+     * Creates a {@code notifications/tools/list_changed} notification.
+     *
+     * @return a tools-list-changed notification
+     */
     public static JsonRpcNotification toolsListChanged() {
         return new JsonRpcNotification("notifications/tools/list_changed");
     }
 
+    /**
+     * Creates a {@code notifications/resources/list_changed} notification.
+     *
+     * @return a resources-list-changed notification
+     */
     public static JsonRpcNotification resourcesListChanged() {
         return new JsonRpcNotification("notifications/resources/list_changed");
     }
 
+    /**
+     * Creates a {@code notifications/resources/updated} notification for the given resource URI.
+     *
+     * @param uri the URI of the updated resource
+     * @return a resource-updated notification
+     */
     public static JsonRpcNotification resourceUpdated(String uri) {
         JsonRpcNotification notification = new JsonRpcNotification("notifications/resources/updated");
         notification.params = java.util.Map.of("uri", uri);
         return notification;
     }
 
+    /**
+     * Creates a {@code notifications/prompts/list_changed} notification.
+     *
+     * @return a prompts-list-changed notification
+     */
     public static JsonRpcNotification promptsListChanged() {
         return new JsonRpcNotification("notifications/prompts/list_changed");
     }
 
+    /**
+     * Creates a {@code notifications/progress} notification without a message.
+     *
+     * @param progressToken the token identifying the operation in progress
+     * @param progress the current progress value
+     * @param total the total progress value (ignored if not positive)
+     * @return a progress notification
+     */
     public static JsonRpcNotification progress(Object progressToken, double progress, double total) {
         return progress(progressToken, progress, total, null);
     }
 
+    /**
+     * Creates a {@code notifications/progress} notification with an optional message.
+     *
+     * @param progressToken the token identifying the operation in progress
+     * @param progress the current progress value
+     * @param total the total progress value (ignored if not positive)
+     * @param message an optional human-readable progress message, may be {@code null}
+     * @return a progress notification
+     */
     public static JsonRpcNotification progress(Object progressToken, double progress, double total, String message) {
         JsonRpcNotification notification = new JsonRpcNotification("notifications/progress");
         java.util.Map<String, Object> params = new java.util.LinkedHashMap<>();
@@ -50,26 +98,56 @@ public class JsonRpcNotification {
         return notification;
     }
 
+    /**
+     * Returns the JSON-RPC protocol version.
+     *
+     * @return the protocol version string, always {@code "2.0"}
+     */
     public String getJsonrpc() {
         return jsonrpc;
     }
 
+    /**
+     * Sets the JSON-RPC protocol version.
+     *
+     * @param jsonrpc the protocol version string
+     */
     public void setJsonrpc(String jsonrpc) {
         this.jsonrpc = jsonrpc;
     }
 
+    /**
+     * Returns the notification method name.
+     *
+     * @return the method name
+     */
     public String getMethod() {
         return method;
     }
 
+    /**
+     * Sets the notification method name.
+     *
+     * @param method the method name
+     */
     public void setMethod(String method) {
         this.method = method;
     }
 
+    /**
+     * Returns the notification parameters.
+     *
+     * @return the parameters, or {@code null} if none
+     */
     public Object getParams() {
         return params;
     }
 
+    /**
+     * Sets the notification parameters.
+     *
+     * @param params the parameters
+     */
     public void setParams(Object params) {
         this.params = params;
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/protocol/JsonRpcRequest.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/protocol/JsonRpcRequest.java
@@ -2,6 +2,10 @@ package dev.langchain4j.cdi.mcp.server.protocol;
 
 import jakarta.json.JsonObject;
 
+/**
+ * A JSON-RPC 2.0 request received from a client. Contains the method to invoke, parameters, and a unique request
+ * identifier for correlating the response.
+ */
 public class JsonRpcRequest {
 
     private String jsonrpc = "2.0";
@@ -10,50 +14,108 @@ public class JsonRpcRequest {
     private JsonObject params;
     private Object progressToken;
 
+    /** Default constructor for deserialization. */
     public JsonRpcRequest() {}
 
+    /**
+     * Creates a request with the given id, method, and parameters.
+     *
+     * @param id the request identifier
+     * @param method the JSON-RPC method name
+     * @param params the method parameters
+     */
     public JsonRpcRequest(Object id, String method, JsonObject params) {
         this.id = id;
         this.method = method;
         this.params = params;
     }
 
+    /**
+     * Returns the JSON-RPC protocol version.
+     *
+     * @return the protocol version string, always {@code "2.0"}
+     */
     public String getJsonrpc() {
         return jsonrpc;
     }
 
+    /**
+     * Sets the JSON-RPC protocol version.
+     *
+     * @param jsonrpc the protocol version string
+     */
     public void setJsonrpc(String jsonrpc) {
         this.jsonrpc = jsonrpc;
     }
 
+    /**
+     * Returns the request identifier used to correlate the response.
+     *
+     * @return the request id
+     */
     public Object getId() {
         return id;
     }
 
+    /**
+     * Sets the request identifier.
+     *
+     * @param id the request id
+     */
     public void setId(Object id) {
         this.id = id;
     }
 
+    /**
+     * Returns the JSON-RPC method name to invoke.
+     *
+     * @return the method name
+     */
     public String getMethod() {
         return method;
     }
 
+    /**
+     * Sets the JSON-RPC method name.
+     *
+     * @param method the method name
+     */
     public void setMethod(String method) {
         this.method = method;
     }
 
+    /**
+     * Returns the method parameters.
+     *
+     * @return the parameters as a JSON object, or {@code null} if none
+     */
     public JsonObject getParams() {
         return params;
     }
 
+    /**
+     * Sets the method parameters.
+     *
+     * @param params the parameters as a JSON object
+     */
     public void setParams(JsonObject params) {
         this.params = params;
     }
 
+    /**
+     * Returns the progress token for tracking long-running operations.
+     *
+     * @return the progress token, or {@code null} if not set
+     */
     public Object getProgressToken() {
         return progressToken;
     }
 
+    /**
+     * Sets the progress token for tracking long-running operations.
+     *
+     * @param progressToken the progress token
+     */
     public void setProgressToken(Object progressToken) {
         this.progressToken = progressToken;
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/protocol/JsonRpcResponse.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/protocol/JsonRpcResponse.java
@@ -1,5 +1,9 @@
 package dev.langchain4j.cdi.mcp.server.protocol;
 
+/**
+ * A JSON-RPC 2.0 response. Contains either a {@code result} (on success) or an {@code error} (on failure), correlated
+ * to a request by {@code id}.
+ */
 public class JsonRpcResponse {
 
     private String jsonrpc = "2.0";
@@ -7,8 +11,16 @@ public class JsonRpcResponse {
     private Object result;
     private JsonRpcError error;
 
+    /** Default constructor for deserialization. */
     public JsonRpcResponse() {}
 
+    /**
+     * Creates a successful response with the given id and result.
+     *
+     * @param id the request identifier this response corresponds to
+     * @param result the result payload
+     * @return a success response
+     */
     public static JsonRpcResponse success(Object id, Object result) {
         JsonRpcResponse response = new JsonRpcResponse();
         response.id = id;
@@ -16,6 +28,13 @@ public class JsonRpcResponse {
         return response;
     }
 
+    /**
+     * Creates an error response with the given id and error details.
+     *
+     * @param id the request identifier this response corresponds to
+     * @param error the error details
+     * @return an error response
+     */
     public static JsonRpcResponse error(Object id, JsonRpcError error) {
         JsonRpcResponse response = new JsonRpcResponse();
         response.id = id;
@@ -23,34 +42,74 @@ public class JsonRpcResponse {
         return response;
     }
 
+    /**
+     * Returns the JSON-RPC protocol version.
+     *
+     * @return the protocol version string, always {@code "2.0"}
+     */
     public String getJsonrpc() {
         return jsonrpc;
     }
 
+    /**
+     * Sets the JSON-RPC protocol version.
+     *
+     * @param jsonrpc the protocol version string
+     */
     public void setJsonrpc(String jsonrpc) {
         this.jsonrpc = jsonrpc;
     }
 
+    /**
+     * Returns the request identifier this response corresponds to.
+     *
+     * @return the request id
+     */
     public Object getId() {
         return id;
     }
 
+    /**
+     * Sets the request identifier.
+     *
+     * @param id the request id
+     */
     public void setId(Object id) {
         this.id = id;
     }
 
+    /**
+     * Returns the result payload on success.
+     *
+     * @return the result, or {@code null} if this is an error response
+     */
     public Object getResult() {
         return result;
     }
 
+    /**
+     * Sets the result payload.
+     *
+     * @param result the result
+     */
     public void setResult(Object result) {
         this.result = result;
     }
 
+    /**
+     * Returns the error details on failure.
+     *
+     * @return the error, or {@code null} if this is a success response
+     */
     public JsonRpcError getError() {
         return error;
     }
 
+    /**
+     * Sets the error details.
+     *
+     * @param error the error
+     */
     public void setError(JsonRpcError error) {
         this.error = error;
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/protocol/JsonRpcServerRequest.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/protocol/JsonRpcServerRequest.java
@@ -11,42 +11,90 @@ public class JsonRpcServerRequest {
     private String method;
     private Object params;
 
+    /** Default constructor for deserialization. */
     public JsonRpcServerRequest() {}
 
+    /**
+     * Creates a server request with the given id, method, and parameters.
+     *
+     * @param id the request identifier for correlating the client response
+     * @param method the JSON-RPC method name
+     * @param params the method parameters
+     */
     public JsonRpcServerRequest(Object id, String method, Object params) {
         this.id = id;
         this.method = method;
         this.params = params;
     }
 
+    /**
+     * Returns the JSON-RPC protocol version.
+     *
+     * @return the protocol version string, always {@code "2.0"}
+     */
     public String getJsonrpc() {
         return jsonrpc;
     }
 
+    /**
+     * Sets the JSON-RPC protocol version.
+     *
+     * @param jsonrpc the protocol version string
+     */
     public void setJsonrpc(String jsonrpc) {
         this.jsonrpc = jsonrpc;
     }
 
+    /**
+     * Returns the request identifier for correlating the client response.
+     *
+     * @return the request id
+     */
     public Object getId() {
         return id;
     }
 
+    /**
+     * Sets the request identifier.
+     *
+     * @param id the request id
+     */
     public void setId(Object id) {
         this.id = id;
     }
 
+    /**
+     * Returns the JSON-RPC method name.
+     *
+     * @return the method name
+     */
     public String getMethod() {
         return method;
     }
 
+    /**
+     * Sets the JSON-RPC method name.
+     *
+     * @param method the method name
+     */
     public void setMethod(String method) {
         this.method = method;
     }
 
+    /**
+     * Returns the method parameters.
+     *
+     * @return the parameters, or {@code null} if none
+     */
     public Object getParams() {
         return params;
     }
 
+    /**
+     * Sets the method parameters.
+     *
+     * @param params the parameters
+     */
     public void setParams(Object params) {
         this.params = params;
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/protocol/McpPagination.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/protocol/McpPagination.java
@@ -6,10 +6,17 @@ import java.util.List;
 /** Utility for cursor-based pagination. Cursors are base64-encoded offsets. */
 public final class McpPagination {
 
+    /** Default number of items per page. */
     public static final int DEFAULT_PAGE_SIZE = 50;
 
     private McpPagination() {}
 
+    /**
+     * Decodes a base64-encoded cursor into a numeric offset.
+     *
+     * @param cursor the base64-encoded cursor, or {@code null}/empty to start from the beginning
+     * @return the decoded offset, or {@code 0} if the cursor is absent or invalid
+     */
     public static int decodeOffset(String cursor) {
         if (cursor == null || cursor.isEmpty()) {
             return 0;
@@ -21,14 +28,37 @@ public final class McpPagination {
         }
     }
 
+    /**
+     * Encodes an offset into a base64 cursor string.
+     *
+     * @param offset the numeric offset to encode
+     * @return the base64-encoded cursor
+     */
     public static String encodeCursor(int offset) {
         return Base64.getEncoder().encodeToString(Integer.toString(offset).getBytes());
     }
 
+    /**
+     * Paginates a list using the {@link #DEFAULT_PAGE_SIZE default page size}.
+     *
+     * @param <T> the element type
+     * @param items the full list of items
+     * @param cursor the base64-encoded cursor, or {@code null} to start from the beginning
+     * @return a page containing the items and an optional next cursor
+     */
     public static <T> Page<T> paginate(List<T> items, String cursor) {
         return paginate(items, cursor, DEFAULT_PAGE_SIZE);
     }
 
+    /**
+     * Paginates a list with a specified page size.
+     *
+     * @param <T> the element type
+     * @param items the full list of items
+     * @param cursor the base64-encoded cursor, or {@code null} to start from the beginning
+     * @param pageSize the maximum number of items per page
+     * @return a page containing the items and an optional next cursor
+     */
     public static <T> Page<T> paginate(List<T> items, String cursor, int pageSize) {
         int offset = decodeOffset(cursor);
         int end = Math.min(offset + pageSize, items.size());
@@ -37,5 +67,12 @@ public final class McpPagination {
         return new Page<>(page, nextCursor);
     }
 
+    /**
+     * A single page of results with an optional cursor to the next page.
+     *
+     * @param <T> the element type
+     * @param items the items in this page
+     * @param nextCursor the cursor for the next page, or {@code null} if this is the last page
+     */
     public record Page<T>(List<T> items, String nextCursor) {}
 }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/protocol/McpPromptGetResult.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/protocol/McpPromptGetResult.java
@@ -2,30 +2,61 @@ package dev.langchain4j.cdi.mcp.server.protocol;
 
 import java.util.List;
 
+/** Result of an MCP {@code prompts/get} request, containing a description and a list of messages. */
 public class McpPromptGetResult {
 
+    /** Human-readable description of the prompt. */
     private String description;
+
+    /** Ordered list of messages that make up the prompt. */
     private List<McpPromptMessage> messages;
 
+    /** Default constructor for JSON-B deserialization. */
     public McpPromptGetResult() {}
 
+    /**
+     * Creates a result with the given description and messages.
+     *
+     * @param description the prompt description
+     * @param messages the prompt messages
+     */
     public McpPromptGetResult(String description, List<McpPromptMessage> messages) {
         this.description = description;
         this.messages = messages;
     }
 
+    /**
+     * Returns the prompt description.
+     *
+     * @return the description
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * Sets the prompt description.
+     *
+     * @param description the description
+     */
     public void setDescription(String description) {
         this.description = description;
     }
 
+    /**
+     * Returns the prompt messages.
+     *
+     * @return the messages
+     */
     public List<McpPromptMessage> getMessages() {
         return messages;
     }
 
+    /**
+     * Sets the prompt messages.
+     *
+     * @param messages the messages
+     */
     public void setMessages(List<McpPromptMessage> messages) {
         this.messages = messages;
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/protocol/McpPromptMessage.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/protocol/McpPromptMessage.java
@@ -12,36 +12,78 @@ import org.mcp_java.model.content.TextContent;
  */
 public class McpPromptMessage {
 
+    /** The message role ({@code "user"} or {@code "assistant"}). */
     private String role;
+
+    /** The text content of this message. */
     private TextContent content;
 
+    /** Default constructor for JSON-B deserialization. */
     public McpPromptMessage() {}
 
+    /**
+     * Creates a prompt message with the given role and content.
+     *
+     * @param role the role ({@code "user"} or {@code "assistant"})
+     * @param content the text content
+     */
     public McpPromptMessage(String role, TextContent content) {
         this.role = role;
         this.content = content;
     }
 
+    /**
+     * Creates a user message with the given text.
+     *
+     * @param text the message text
+     * @return a new user prompt message
+     */
     public static McpPromptMessage user(String text) {
         return new McpPromptMessage("user", TextContent.of(text));
     }
 
+    /**
+     * Creates an assistant message with the given text.
+     *
+     * @param text the message text
+     * @return a new assistant prompt message
+     */
     public static McpPromptMessage assistant(String text) {
         return new McpPromptMessage("assistant", TextContent.of(text));
     }
 
+    /**
+     * Returns the message role.
+     *
+     * @return the role
+     */
     public String getRole() {
         return role;
     }
 
+    /**
+     * Sets the message role.
+     *
+     * @param role the role
+     */
     public void setRole(String role) {
         this.role = role;
     }
 
+    /**
+     * Returns the message content.
+     *
+     * @return the text content
+     */
     public TextContent getContent() {
         return content;
     }
 
+    /**
+     * Sets the message content.
+     *
+     * @param content the text content
+     */
     public void setContent(TextContent content) {
         this.content = content;
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpBeanInvoker.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpBeanInvoker.java
@@ -24,6 +24,9 @@ import org.mcp_java.annotations.tools.ToolArg;
 @ApplicationScoped
 public class McpBeanInvoker {
 
+    /** CDI-required default constructor. */
+    public McpBeanInvoker() {}
+
     private static final String DEFAULT_NAME = "<<element name>>";
 
     @Inject
@@ -32,12 +35,30 @@ public class McpBeanInvoker {
     @Inject
     McpApiFactory apiFactory;
 
-    /** Invokes a method without MCP framework context (backward compatible). */
+    /**
+     * Invokes a method without MCP framework context (backward compatible).
+     *
+     * @param requestId the JSON-RPC request ID for error reporting
+     * @param beanType the CDI bean class to look up and invoke
+     * @param method the method to invoke on the resolved bean
+     * @param arguments the JSON object containing method arguments
+     * @return the method invocation result
+     */
     public Object invoke(Object requestId, Class<?> beanType, Method method, JsonObject arguments) {
         return invoke(requestId, beanType, method, arguments, null, null);
     }
 
-    /** Invokes a method with MCP framework context, enabling framework type injection. */
+    /**
+     * Invokes a method with MCP framework context, enabling framework type injection.
+     *
+     * @param requestId the JSON-RPC request ID for error reporting
+     * @param beanType the CDI bean class to look up and invoke
+     * @param method the method to invoke on the resolved bean
+     * @param arguments the JSON object containing method arguments
+     * @param ctx the MCP request context, or {@code null} if unavailable
+     * @param session the MCP session, or {@code null} if unavailable
+     * @return the method invocation result
+     */
     public Object invoke(
             Object requestId,
             Class<?> beanType,

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpPromptDescriptor.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpPromptDescriptor.java
@@ -7,6 +7,10 @@ import java.util.List;
 import org.mcp_java.annotations.prompts.Prompt;
 import org.mcp_java.annotations.prompts.PromptArg;
 
+/**
+ * Describes an MCP prompt extracted from a {@link Prompt}-annotated method, including its name, description, arguments,
+ * owning bean type, and target method.
+ */
 public class McpPromptDescriptor {
 
     private static final String DEFAULT_NAME = "<<element name>>";
@@ -17,6 +21,15 @@ public class McpPromptDescriptor {
     private final Class<?> beanType;
     private final Method method;
 
+    /**
+     * Creates a new prompt descriptor.
+     *
+     * @param name the prompt name
+     * @param description the prompt description
+     * @param arguments the list of prompt arguments
+     * @param beanType the CDI bean class that declares the prompt method
+     * @param method the annotated method
+     */
     public McpPromptDescriptor(
             String name, String description, List<PromptArgument> arguments, Class<?> beanType, Method method) {
         this.name = name;
@@ -26,6 +39,13 @@ public class McpPromptDescriptor {
         this.method = method;
     }
 
+    /**
+     * Creates a descriptor by inspecting a {@link Prompt}-annotated method and its parameters.
+     *
+     * @param beanClass the CDI bean class that declares the method
+     * @param method the {@code @Prompt}-annotated method
+     * @return a new descriptor built from the method's annotation metadata
+     */
     public static McpPromptDescriptor fromMethod(Class<?> beanClass, Method method) {
         Prompt annotation = method.getAnnotation(Prompt.class);
         String name = DEFAULT_NAME.equals(annotation.name()) ? method.getName() : annotation.name();
@@ -41,25 +61,57 @@ public class McpPromptDescriptor {
         return new McpPromptDescriptor(name, annotation.description(), args, beanClass, method);
     }
 
+    /**
+     * Returns the prompt name.
+     *
+     * @return the prompt name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Returns the prompt description.
+     *
+     * @return the prompt description
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * Returns the list of prompt arguments.
+     *
+     * @return the list of prompt arguments
+     */
     public List<PromptArgument> getArguments() {
         return arguments;
     }
 
+    /**
+     * Returns the CDI bean class that declares the prompt method.
+     *
+     * @return the bean class
+     */
     public Class<?> getBeanType() {
         return beanType;
     }
 
+    /**
+     * Returns the annotated method that implements this prompt.
+     *
+     * @return the prompt method
+     */
     public Method getMethod() {
         return method;
     }
 
+    /**
+     * A prompt argument descriptor.
+     *
+     * @param name the argument name
+     * @param description the argument description
+     * @param required whether the argument is required
+     */
     public record PromptArgument(String name, String description, boolean required) {}
 }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpPromptRegistry.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpPromptRegistry.java
@@ -10,6 +10,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * Application-scoped registry of MCP prompt descriptors. Manages prompt registration, lookup, and broadcasts
+ * list-changed notifications to connected clients when the set of prompts changes.
+ */
 @ApplicationScoped
 public class McpPromptRegistry {
 
@@ -18,6 +22,14 @@ public class McpPromptRegistry {
     @Inject
     McpNotificationBroadcaster broadcaster;
 
+    /** CDI-required default constructor. */
+    public McpPromptRegistry() {}
+
+    /**
+     * Registers a prompt descriptor. Broadcasts a list-changed notification if this is a new prompt.
+     *
+     * @param descriptor the prompt descriptor to register
+     */
     public void register(McpPromptDescriptor descriptor) {
         McpPromptDescriptor previous = prompts.put(descriptor.getName(), descriptor);
         if (previous == null && broadcaster != null && broadcaster.connectedStreamCount() > 0) {
@@ -25,6 +37,12 @@ public class McpPromptRegistry {
         }
     }
 
+    /**
+     * Removes a prompt by name. Broadcasts a list-changed notification if the prompt existed.
+     *
+     * @param name the prompt name
+     * @return {@code true} if a prompt was removed
+     */
     public boolean unregister(String name) {
         McpPromptDescriptor removed = prompts.remove(name);
         if (removed != null && broadcaster != null && broadcaster.connectedStreamCount() > 0) {
@@ -33,14 +51,30 @@ public class McpPromptRegistry {
         return removed != null;
     }
 
+    /**
+     * Returns an unmodifiable view of all registered prompt descriptors.
+     *
+     * @return the registered prompts
+     */
     public Collection<McpPromptDescriptor> listPrompts() {
         return Collections.unmodifiableCollection(prompts.values());
     }
 
+    /**
+     * Finds a prompt descriptor by name.
+     *
+     * @param name the prompt name
+     * @return an {@link Optional} containing the descriptor, or empty if not found
+     */
     public Optional<McpPromptDescriptor> findPrompt(String name) {
         return Optional.ofNullable(prompts.get(name));
     }
 
+    /**
+     * Returns the number of registered prompts.
+     *
+     * @return the prompt count
+     */
     public int size() {
         return prompts.size();
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpResourceDescriptor.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpResourceDescriptor.java
@@ -3,6 +3,10 @@ package dev.langchain4j.cdi.mcp.server.registry;
 import java.lang.reflect.Method;
 import org.mcp_java.annotations.resources.Resource;
 
+/**
+ * Describes an MCP resource extracted from a {@link Resource}-annotated method, including its URI, name, description,
+ * MIME type, owning bean type, and target method.
+ */
 public class McpResourceDescriptor {
 
     private static final String DEFAULT_NAME = "<<element name>>";
@@ -14,6 +18,16 @@ public class McpResourceDescriptor {
     private final Class<?> beanType;
     private final Method method;
 
+    /**
+     * Creates a new resource descriptor.
+     *
+     * @param uri the resource URI
+     * @param name the resource name
+     * @param description the resource description
+     * @param mimeType the MIME type of the resource content
+     * @param beanType the CDI bean class that declares the resource method
+     * @param method the annotated method
+     */
     public McpResourceDescriptor(
             String uri, String name, String description, String mimeType, Class<?> beanType, Method method) {
         this.uri = uri;
@@ -24,6 +38,13 @@ public class McpResourceDescriptor {
         this.method = method;
     }
 
+    /**
+     * Creates a descriptor by inspecting a {@link Resource}-annotated method.
+     *
+     * @param beanClass the CDI bean class that declares the method
+     * @param method the {@code @Resource}-annotated method
+     * @return a new descriptor built from the method's annotation metadata
+     */
     public static McpResourceDescriptor fromMethod(Class<?> beanClass, Method method) {
         Resource annotation = method.getAnnotation(Resource.class);
         String name = DEFAULT_NAME.equals(annotation.name()) ? method.getName() : annotation.name();
@@ -31,26 +52,56 @@ public class McpResourceDescriptor {
         return new McpResourceDescriptor(annotation.uri(), name, annotation.description(), mimeType, beanClass, method);
     }
 
+    /**
+     * Returns the resource URI.
+     *
+     * @return the resource URI
+     */
     public String getUri() {
         return uri;
     }
 
+    /**
+     * Returns the resource name.
+     *
+     * @return the resource name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Returns the resource description.
+     *
+     * @return the resource description
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * Returns the MIME type of the resource content.
+     *
+     * @return the MIME type
+     */
     public String getMimeType() {
         return mimeType;
     }
 
+    /**
+     * Returns the CDI bean class that declares the resource method.
+     *
+     * @return the bean class
+     */
     public Class<?> getBeanType() {
         return beanType;
     }
 
+    /**
+     * Returns the annotated method that provides this resource.
+     *
+     * @return the resource method
+     */
     public Method getMethod() {
         return method;
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpResourceRegistry.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpResourceRegistry.java
@@ -11,6 +11,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * Application-scoped registry of MCP resource and resource-template descriptors. Manages registration, lookup, and
+ * broadcasts list-changed and resource-updated notifications to connected clients.
+ */
 @ApplicationScoped
 public class McpResourceRegistry {
 
@@ -23,6 +27,14 @@ public class McpResourceRegistry {
     @Inject
     McpResourceSubscriptionManager subscriptionManager;
 
+    /** CDI-required default constructor. */
+    public McpResourceRegistry() {}
+
+    /**
+     * Registers a resource descriptor. Broadcasts a list-changed notification if this is a new resource.
+     *
+     * @param descriptor the resource descriptor to register
+     */
     public void register(McpResourceDescriptor descriptor) {
         McpResourceDescriptor previous = resources.put(descriptor.getUri(), descriptor);
         if (previous == null) {
@@ -30,6 +42,12 @@ public class McpResourceRegistry {
         }
     }
 
+    /**
+     * Removes a resource by URI. Broadcasts a list-changed notification if the resource existed.
+     *
+     * @param uri the resource URI
+     * @return {@code true} if a resource was removed
+     */
     public boolean unregister(String uri) {
         McpResourceDescriptor removed = resources.remove(uri);
         if (removed != null) {
@@ -38,6 +56,11 @@ public class McpResourceRegistry {
         return removed != null;
     }
 
+    /**
+     * Registers a resource template descriptor. Broadcasts a list-changed notification if this is a new template.
+     *
+     * @param descriptor the resource template descriptor to register
+     */
     public void registerTemplate(McpResourceTemplateDescriptor descriptor) {
         McpResourceTemplateDescriptor previous = templates.put(descriptor.getUriTemplate(), descriptor);
         if (previous == null) {
@@ -45,6 +68,11 @@ public class McpResourceRegistry {
         }
     }
 
+    /**
+     * Sends a resource-updated notification to all sessions subscribed to the given URI.
+     *
+     * @param uri the URI of the updated resource
+     */
     public void notifyResourceUpdated(String uri) {
         if (broadcaster == null || subscriptionManager == null) {
             return;
@@ -61,26 +89,58 @@ public class McpResourceRegistry {
         }
     }
 
+    /**
+     * Returns an unmodifiable view of all registered resource descriptors.
+     *
+     * @return the registered resources
+     */
     public Collection<McpResourceDescriptor> listResources() {
         return Collections.unmodifiableCollection(resources.values());
     }
 
+    /**
+     * Returns an unmodifiable view of all registered resource template descriptors.
+     *
+     * @return the registered resource templates
+     */
     public Collection<McpResourceTemplateDescriptor> listTemplates() {
         return Collections.unmodifiableCollection(templates.values());
     }
 
+    /**
+     * Finds a resource descriptor by URI.
+     *
+     * @param uri the resource URI
+     * @return an {@link Optional} containing the descriptor, or empty if not found
+     */
     public Optional<McpResourceDescriptor> findResource(String uri) {
         return Optional.ofNullable(resources.get(uri));
     }
 
+    /**
+     * Finds a resource template descriptor by URI template.
+     *
+     * @param uriTemplate the URI template string
+     * @return an {@link Optional} containing the descriptor, or empty if not found
+     */
     public Optional<McpResourceTemplateDescriptor> findTemplate(String uriTemplate) {
         return Optional.ofNullable(templates.get(uriTemplate));
     }
 
+    /**
+     * Returns the number of registered resources.
+     *
+     * @return the resource count
+     */
     public int size() {
         return resources.size();
     }
 
+    /**
+     * Returns the number of registered resource templates.
+     *
+     * @return the template count
+     */
     public int templateSize() {
         return templates.size();
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpResourceTemplateDescriptor.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpResourceTemplateDescriptor.java
@@ -3,6 +3,10 @@ package dev.langchain4j.cdi.mcp.server.registry;
 import java.lang.reflect.Method;
 import org.mcp_java.annotations.resources.ResourceTemplate;
 
+/**
+ * Describes an MCP resource template extracted from a {@link ResourceTemplate}-annotated method, including its URI
+ * template, name, description, MIME type, owning bean type, and target method.
+ */
 public class McpResourceTemplateDescriptor {
 
     private static final String DEFAULT_NAME = "<<element name>>";
@@ -14,6 +18,16 @@ public class McpResourceTemplateDescriptor {
     private final Class<?> beanType;
     private final Method method;
 
+    /**
+     * Creates a new resource template descriptor.
+     *
+     * @param uriTemplate the URI template pattern
+     * @param name the resource template name
+     * @param description the resource template description
+     * @param mimeType the MIME type of the resource content
+     * @param beanType the CDI bean class that declares the resource template method
+     * @param method the annotated method
+     */
     public McpResourceTemplateDescriptor(
             String uriTemplate, String name, String description, String mimeType, Class<?> beanType, Method method) {
         this.uriTemplate = uriTemplate;
@@ -24,6 +38,13 @@ public class McpResourceTemplateDescriptor {
         this.method = method;
     }
 
+    /**
+     * Creates a descriptor by inspecting a {@link ResourceTemplate}-annotated method.
+     *
+     * @param beanClass the CDI bean class that declares the method
+     * @param method the {@code @ResourceTemplate}-annotated method
+     * @return a new descriptor built from the method's annotation metadata
+     */
     public static McpResourceTemplateDescriptor fromMethod(Class<?> beanClass, Method method) {
         ResourceTemplate annotation = method.getAnnotation(ResourceTemplate.class);
         String name = DEFAULT_NAME.equals(annotation.name()) ? method.getName() : annotation.name();
@@ -32,26 +53,56 @@ public class McpResourceTemplateDescriptor {
                 annotation.uriTemplate(), name, annotation.description(), mimeType, beanClass, method);
     }
 
+    /**
+     * Returns the URI template pattern.
+     *
+     * @return the URI template
+     */
     public String getUriTemplate() {
         return uriTemplate;
     }
 
+    /**
+     * Returns the resource template name.
+     *
+     * @return the template name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Returns the resource template description.
+     *
+     * @return the template description
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * Returns the MIME type of the resource content.
+     *
+     * @return the MIME type
+     */
     public String getMimeType() {
         return mimeType;
     }
 
+    /**
+     * Returns the CDI bean class that declares the resource template method.
+     *
+     * @return the bean class
+     */
     public Class<?> getBeanType() {
         return beanType;
     }
 
+    /**
+     * Returns the annotated method that provides this resource template.
+     *
+     * @return the resource template method
+     */
     public Method getMethod() {
         return method;
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpToolDescriptor.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpToolDescriptor.java
@@ -5,6 +5,7 @@ import jakarta.json.JsonObject;
 import java.lang.reflect.Method;
 import org.mcp_java.annotations.tools.Tool;
 
+/** Describes a discovered MCP tool, holding its metadata, JSON Schema, and the backing bean method. */
 public class McpToolDescriptor {
 
     private static final String DEFAULT_NAME = "<<element name>>";
@@ -15,6 +16,15 @@ public class McpToolDescriptor {
     private final Class<?> beanType;
     private final Method method;
 
+    /**
+     * Creates a tool descriptor with the given metadata.
+     *
+     * @param name the tool name
+     * @param description a human-readable description of the tool
+     * @param inputSchema the JSON Schema describing the tool's input parameters
+     * @param beanType the CDI bean class that declares the tool method
+     * @param method the reflective method reference to invoke
+     */
     public McpToolDescriptor(
             String name, String description, JsonObject inputSchema, Class<?> beanType, Method method) {
         this.name = name;
@@ -24,6 +34,13 @@ public class McpToolDescriptor {
         this.method = method;
     }
 
+    /**
+     * Creates a descriptor by inspecting a {@link Tool}-annotated method.
+     *
+     * @param beanClass the CDI bean class that declares the method
+     * @param method the method annotated with {@link Tool}
+     * @return a new descriptor populated from the annotation and method signature
+     */
     public static McpToolDescriptor fromMethod(Class<?> beanClass, Method method) {
         Tool tool = method.getAnnotation(Tool.class);
         String toolName = DEFAULT_NAME.equals(tool.name()) ? method.getName() : tool.name();
@@ -32,26 +49,56 @@ public class McpToolDescriptor {
                 toolName, toolDescription, JsonSchemaGenerator.fromMethod(method), beanClass, method);
     }
 
+    /**
+     * Converts this descriptor to the MCP wire-format tool representation.
+     *
+     * @return an MCP {@link org.mcp_java.model.tool.Tool} suitable for JSON serialization
+     */
     public org.mcp_java.model.tool.Tool toWireFormat() {
         return new org.mcp_java.model.tool.Tool(name, null, description, inputSchema, null, null, null);
     }
 
+    /**
+     * Returns the tool name.
+     *
+     * @return the tool name
+     */
     public String getName() {
         return name;
     }
 
+    /**
+     * Returns the human-readable tool description.
+     *
+     * @return the tool description
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * Returns the JSON Schema describing the tool's input parameters.
+     *
+     * @return the input schema as a JSON object
+     */
     public JsonObject getInputSchema() {
         return inputSchema;
     }
 
+    /**
+     * Returns the CDI bean class that declares the tool method.
+     *
+     * @return the bean class
+     */
     public Class<?> getBeanType() {
         return beanType;
     }
 
+    /**
+     * Returns the reflective method reference for invoking the tool.
+     *
+     * @return the tool method
+     */
     public Method getMethod() {
         return method;
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpToolDiscovery.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpToolDiscovery.java
@@ -17,6 +17,7 @@ import org.mcp_java.annotations.resources.Resource;
 import org.mcp_java.annotations.resources.ResourceTemplate;
 import org.mcp_java.annotations.tools.Tool;
 
+/** CDI bean that discovers {@code @Tool}, {@code @Resource}, and {@code @Prompt} annotated methods at startup. */
 @ApplicationScoped
 public class McpToolDiscovery {
 
@@ -27,6 +28,14 @@ public class McpToolDiscovery {
     private final McpPromptRegistry promptRegistry;
     private final BeanManager beanManager;
 
+    /**
+     * Creates the discovery bean with its required registries.
+     *
+     * @param toolRegistry the tool registry to populate
+     * @param resourceRegistry the resource registry to populate
+     * @param promptRegistry the prompt registry to populate
+     * @param beanManager the CDI bean manager used for bean scanning
+     */
     @Inject
     public McpToolDiscovery(
             McpToolRegistry toolRegistry,

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpToolInvoker.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpToolInvoker.java
@@ -6,16 +6,38 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.json.JsonObject;
 
+/** Invokes MCP tool methods on their owning CDI beans, delegating to {@link McpBeanInvoker}. */
 @ApplicationScoped
 public class McpToolInvoker {
+
+    /** CDI-required default constructor. */
+    public McpToolInvoker() {}
 
     @Inject
     McpBeanInvoker beanInvoker;
 
+    /**
+     * Invokes a tool without request context or session.
+     *
+     * @param requestId the JSON-RPC request ID
+     * @param descriptor the tool descriptor identifying the method to call
+     * @param arguments the JSON object containing the tool's input arguments
+     * @return the tool invocation result
+     */
     public Object invoke(Object requestId, McpToolDescriptor descriptor, JsonObject arguments) {
         return beanInvoker.invoke(requestId, descriptor.getBeanType(), descriptor.getMethod(), arguments);
     }
 
+    /**
+     * Invokes a tool with request context and session for MCP capability injection.
+     *
+     * @param requestId the JSON-RPC request ID
+     * @param descriptor the tool descriptor identifying the method to call
+     * @param arguments the JSON object containing the tool's input arguments
+     * @param ctx the MCP request context for progress and cancellation support
+     * @param session the MCP session for sampling, elicitation, and roots access
+     * @return the tool invocation result
+     */
     public Object invoke(
             Object requestId,
             McpToolDescriptor descriptor,

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpToolRegistry.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/registry/McpToolRegistry.java
@@ -10,14 +10,24 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+/** Thread-safe registry of discovered MCP tools, broadcasting list-changed notifications to connected clients. */
 @ApplicationScoped
 public class McpToolRegistry {
+
+    /** CDI-required default constructor. */
+    public McpToolRegistry() {}
 
     private final Map<String, McpToolDescriptor> tools = new ConcurrentHashMap<>();
 
     @Inject
     McpNotificationBroadcaster broadcaster;
 
+    /**
+     * Registers a tool descriptor, replacing any existing tool with the same name. Broadcasts a tools-list-changed
+     * notification to connected clients when a new tool is added.
+     *
+     * @param descriptor the tool descriptor to register
+     */
     public void register(McpToolDescriptor descriptor) {
         McpToolDescriptor previous = tools.put(descriptor.getName(), descriptor);
         if (previous == null && broadcaster != null && broadcaster.connectedStreamCount() > 0) {
@@ -25,6 +35,12 @@ public class McpToolRegistry {
         }
     }
 
+    /**
+     * Removes a tool by name. Broadcasts a tools-list-changed notification if the tool existed.
+     *
+     * @param toolName the name of the tool to remove
+     * @return {@code true} if the tool was found and removed, {@code false} otherwise
+     */
     public boolean unregister(String toolName) {
         McpToolDescriptor removed = tools.remove(toolName);
         if (removed != null && broadcaster != null && broadcaster.connectedStreamCount() > 0) {
@@ -33,14 +49,30 @@ public class McpToolRegistry {
         return removed != null;
     }
 
+    /**
+     * Returns an unmodifiable view of all registered tool descriptors.
+     *
+     * @return the collection of registered tools
+     */
     public Collection<McpToolDescriptor> listTools() {
         return Collections.unmodifiableCollection(tools.values());
     }
 
+    /**
+     * Looks up a tool by name.
+     *
+     * @param name the tool name
+     * @return an optional containing the descriptor, or empty if not found
+     */
     public Optional<McpToolDescriptor> findTool(String name) {
         return Optional.ofNullable(tools.get(name));
     }
 
+    /**
+     * Returns the number of registered tools.
+     *
+     * @return the tool count
+     */
     public int size() {
         return tools.size();
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/schema/JsonSchemaGenerator.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/schema/JsonSchemaGenerator.java
@@ -11,12 +11,20 @@ import java.util.List;
 import java.util.Set;
 import org.mcp_java.annotations.tools.ToolArg;
 
+/** Generates JSON Schema objects from Java method signatures for MCP tool descriptions. */
 public class JsonSchemaGenerator {
 
     private static final String DEFAULT_NAME = "<<element name>>";
 
+    /** Utility class; not instantiable. */
     private JsonSchemaGenerator() {}
 
+    /**
+     * Builds a JSON Schema describing the parameters of the given method.
+     *
+     * @param method the method whose parameters to describe
+     * @return a JSON Schema object with {@code properties} and {@code required} entries
+     */
     public static JsonObject fromMethod(Method method) {
         JsonObjectBuilder schema = Json.createObjectBuilder().add("type", "object");
         JsonObjectBuilder properties = Json.createObjectBuilder();

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpCancellationManager.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpCancellationManager.java
@@ -14,14 +14,26 @@ public class McpCancellationManager {
 
     private final Map<Object, AtomicBoolean> flags = new ConcurrentHashMap<>();
 
-    /** Registers a new request and returns the cancellation flag. */
+    /** Creates a new cancellation manager with an empty flag map. */
+    public McpCancellationManager() {}
+
+    /**
+     * Registers a new request and returns its cancellation flag.
+     *
+     * @param requestId the JSON-RPC request identifier
+     * @return an {@link AtomicBoolean} that will be set to {@code true} if the request is cancelled
+     */
     public AtomicBoolean register(Object requestId) {
         AtomicBoolean flag = new AtomicBoolean(false);
         flags.put(requestId, flag);
         return flag;
     }
 
-    /** Marks a request as cancelled. */
+    /**
+     * Marks a request as cancelled by setting its flag to {@code true}.
+     *
+     * @param requestId the JSON-RPC request identifier to cancel
+     */
     public void cancel(Object requestId) {
         AtomicBoolean flag = flags.get(requestId);
         if (flag != null) {
@@ -29,7 +41,11 @@ public class McpCancellationManager {
         }
     }
 
-    /** Removes the flag for a completed request. */
+    /**
+     * Removes the cancellation flag for a completed request.
+     *
+     * @param requestId the JSON-RPC request identifier to unregister
+     */
     public void unregister(Object requestId) {
         flags.remove(requestId);
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpElicitationManager.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpElicitationManager.java
@@ -16,6 +16,9 @@ public class McpElicitationManager {
 
     private static final Logger LOGGER = Logger.getLogger(McpElicitationManager.class.getName());
 
+    /** Creates a new elicitation manager. */
+    public McpElicitationManager() {}
+
     @Inject
     McpServerRequestManager requestManager;
 

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpEndpoint.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpEndpoint.java
@@ -62,6 +62,10 @@ import org.mcp_java.model.resource.ResourceContents;
 import org.mcp_java.model.tool.CallToolResult;
 import org.mcp_java.model.tool.ListToolsResult;
 
+/**
+ * JAX-RS resource that implements the MCP Streamable HTTP transport at the {@code /mcp} endpoint. Handles JSON-RPC
+ * requests over POST, SSE streaming over GET, and session termination over DELETE.
+ */
 @Path("/mcp")
 @ApplicationScoped
 @SuppressWarnings("java:S1192")
@@ -93,6 +97,23 @@ public class McpEndpoint {
     /** No-arg constructor required by CDI proxying and JAX-RS runtimes. */
     public McpEndpoint() {}
 
+    /**
+     * CDI injection constructor.
+     *
+     * @param toolRegistry registry of available MCP tools
+     * @param resourceRegistry registry of available MCP resources
+     * @param promptRegistry registry of available MCP prompts
+     * @param sessionManager manages MCP sessions
+     * @param toolInvoker invokes tool methods on CDI beans
+     * @param beanInvoker invokes prompt and resource methods on CDI beans
+     * @param broadcaster broadcasts SSE notifications to connected clients
+     * @param mcpLogger MCP logging facade
+     * @param subscriptionManager manages resource subscriptions
+     * @param serverRequestManager manages server-initiated requests
+     * @param rootsManager handles roots list changes
+     * @param cancellationManager tracks cancellation state per request
+     * @param configInstance optional server configuration bean
+     */
     @Inject
     public McpEndpoint(
             McpToolRegistry toolRegistry,
@@ -123,6 +144,14 @@ public class McpEndpoint {
         this.configInstance = configInstance;
     }
 
+    /**
+     * Handles incoming JSON-RPC requests and client responses over HTTP POST.
+     *
+     * @param body the JSON-RPC request or response body
+     * @param sessionId the MCP session identifier from the request header
+     * @param accept the Accept header value used to determine SSE vs JSON response format
+     * @return the JSON-RPC response, either as JSON or as an SSE event
+     */
     @POST
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces({MediaType.APPLICATION_JSON, MediaType.SERVER_SENT_EVENTS})
@@ -165,6 +194,12 @@ public class McpEndpoint {
         };
     }
 
+    /**
+     * Opens an SSE stream for server-initiated notifications on an existing session.
+     *
+     * @param sessionId the MCP session identifier from the request header
+     * @return an SSE streaming response, or 400 if no session ID is provided
+     */
     @GET
     @Produces(MediaType.SERVER_SENT_EVENTS)
     public Response handleGet(@HeaderParam("Mcp-Session-Id") String sessionId) {
@@ -190,6 +225,12 @@ public class McpEndpoint {
                 .build();
     }
 
+    /**
+     * Terminates an MCP session.
+     *
+     * @param sessionId the MCP session identifier from the request header
+     * @return an OK response after the session is terminated
+     */
     @DELETE
     public Response handleDelete(@HeaderParam("Mcp-Session-Id") String sessionId) {
         if (sessionId != null) {

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpExceptionMapper.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpExceptionMapper.java
@@ -11,9 +11,19 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.ext.ExceptionMapper;
 import jakarta.ws.rs.ext.Provider;
 
+/** JAX-RS exception mapper that converts {@link McpException} instances into JSON-RPC error responses. */
 @Provider
 public class McpExceptionMapper implements ExceptionMapper<McpException> {
 
+    /** Creates a new exception mapper. */
+    public McpExceptionMapper() {}
+
+    /**
+     * Converts an {@link McpException} into a JAX-RS {@link Response} containing a JSON-RPC error object.
+     *
+     * @param e the MCP exception to convert
+     * @return a JSON response with the corresponding JSON-RPC error
+     */
     @Override
     public Response toResponse(McpException e) {
         JsonRpcResponse errorResponse = JsonRpcResponse.error(

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpNotificationBroadcaster.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpNotificationBroadcaster.java
@@ -12,6 +12,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * Broadcasts MCP notifications to connected SSE streams. Maintains a registry of active output streams keyed by session
+ * ID and delivers JSON-RPC notifications to one or all connected clients.
+ */
 @ApplicationScoped
 public class McpNotificationBroadcaster {
 
@@ -19,14 +23,33 @@ public class McpNotificationBroadcaster {
 
     private final Map<String, OutputStream> sseStreams = new ConcurrentHashMap<>();
 
+    /** CDI-required default constructor. */
+    public McpNotificationBroadcaster() {}
+
+    /**
+     * Registers an SSE output stream for a session.
+     *
+     * @param sessionId the session identifier
+     * @param out the output stream to send notifications to
+     */
     public void registerStream(String sessionId, OutputStream out) {
         sseStreams.put(sessionId, out);
     }
 
+    /**
+     * Removes the SSE output stream for a session.
+     *
+     * @param sessionId the session identifier
+     */
     public void unregisterStream(String sessionId) {
         sseStreams.remove(sessionId);
     }
 
+    /**
+     * Sends a notification to all connected SSE streams. Disconnected streams are automatically removed.
+     *
+     * @param notification the notification object to serialize and broadcast
+     */
     public void broadcast(Object notification) {
         String json = serializeToJson(notification);
         String payload = "event: message\ndata: " + json + "\n\n";
@@ -44,6 +67,12 @@ public class McpNotificationBroadcaster {
         });
     }
 
+    /**
+     * Sends a notification to a specific session's SSE stream.
+     *
+     * @param sessionId the target session identifier
+     * @param notification the notification object to serialize and send
+     */
     public void sendToSession(String sessionId, Object notification) {
         OutputStream out = sseStreams.get(sessionId);
         if (out == null) {
@@ -60,6 +89,11 @@ public class McpNotificationBroadcaster {
         }
     }
 
+    /**
+     * Returns the number of currently connected SSE streams.
+     *
+     * @return the count of active SSE streams
+     */
     public int connectedStreamCount() {
         return sseStreams.size();
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpProgressReporter.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpProgressReporter.java
@@ -11,6 +11,9 @@ import jakarta.inject.Inject;
 @ApplicationScoped
 public class McpProgressReporter {
 
+    /** CDI-required default constructor. */
+    public McpProgressReporter() {}
+
     @Inject
     McpNotificationBroadcaster broadcaster;
 

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpResourceSubscriptionManager.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpResourceSubscriptionManager.java
@@ -15,12 +15,27 @@ public class McpResourceSubscriptionManager {
 
     private final Map<String, Set<String>> subscriptionsBySession = new ConcurrentHashMap<>();
 
+    /** CDI-required default constructor. */
+    public McpResourceSubscriptionManager() {}
+
+    /**
+     * Subscribes a session to notifications for the given resource URI.
+     *
+     * @param sessionId the session identifier
+     * @param uri the resource URI to subscribe to
+     */
     public void subscribe(String sessionId, String uri) {
         subscriptionsBySession
                 .computeIfAbsent(sessionId, k -> ConcurrentHashMap.newKeySet())
                 .add(uri);
     }
 
+    /**
+     * Removes a session's subscription to the given resource URI.
+     *
+     * @param sessionId the session identifier
+     * @param uri the resource URI to unsubscribe from
+     */
     public void unsubscribe(String sessionId, String uri) {
         Set<String> uris = subscriptionsBySession.get(sessionId);
         if (uris != null) {
@@ -28,6 +43,12 @@ public class McpResourceSubscriptionManager {
         }
     }
 
+    /**
+     * Returns the set of session IDs subscribed to the given resource URI.
+     *
+     * @param uri the resource URI
+     * @return set of subscribed session IDs
+     */
     public Set<String> getSubscribedSessions(String uri) {
         Set<String> sessions = ConcurrentHashMap.newKeySet();
         subscriptionsBySession.forEach((sessionId, uris) -> {
@@ -38,11 +59,22 @@ public class McpResourceSubscriptionManager {
         return sessions;
     }
 
+    /**
+     * Returns the set of resource URIs that a session is subscribed to.
+     *
+     * @param sessionId the session identifier
+     * @return unmodifiable set of subscribed URIs, or empty set if none
+     */
     public Set<String> getSubscriptions(String sessionId) {
         Set<String> uris = subscriptionsBySession.get(sessionId);
         return uris != null ? Collections.unmodifiableSet(uris) : Collections.emptySet();
     }
 
+    /**
+     * Removes all subscriptions for a session.
+     *
+     * @param sessionId the session identifier
+     */
     public void removeSession(String sessionId) {
         subscriptionsBySession.remove(sessionId);
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpRootsManager.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpRootsManager.java
@@ -23,6 +23,9 @@ public class McpRootsManager {
     @Inject
     McpServerRequestManager requestManager;
 
+    /** CDI-required default constructor. */
+    public McpRootsManager() {}
+
     private final Map<String, List<Root>> rootsBySession = new ConcurrentHashMap<>();
 
     /**
@@ -44,16 +47,30 @@ public class McpRootsManager {
         return roots;
     }
 
-    /** Called when a client sends {@code notifications/roots/list_changed}. Re-requests the roots. */
+    /**
+     * Called when a client sends {@code notifications/roots/list_changed}. Re-requests the roots.
+     *
+     * @param sessionId the session whose roots changed
+     */
     public void onRootsChanged(String sessionId) {
         requestRoots(sessionId);
     }
 
-    /** Returns the cached roots for a session. */
+    /**
+     * Returns the cached roots for a session.
+     *
+     * @param sessionId the session identifier
+     * @return the list of roots, or empty list if none are cached
+     */
     public List<Root> getRoots(String sessionId) {
         return rootsBySession.getOrDefault(sessionId, Collections.emptyList());
     }
 
+    /**
+     * Removes cached roots for a session that has been terminated.
+     *
+     * @param sessionId the session identifier to remove
+     */
     public void removeSession(String sessionId) {
         rootsBySession.remove(sessionId);
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpSamplingManager.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpSamplingManager.java
@@ -20,6 +20,9 @@ public class McpSamplingManager {
     @Inject
     McpServerRequestManager requestManager;
 
+    /** CDI-required default constructor. */
+    public McpSamplingManager() {}
+
     /**
      * Requests the client to create a message using its LLM.
      *

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpServerConfig.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpServerConfig.java
@@ -1,52 +1,109 @@
 package dev.langchain4j.cdi.mcp.server.transport;
 
+/** Configuration holder for MCP server identity, providing the server name and version used during initialization. */
 public class McpServerConfig {
 
+    /** The server name advertised to clients. Defaults to {@code "langchain4j-cdi"}. */
     private String serverName = "langchain4j-cdi";
+
+    /** The server version advertised to clients. Defaults to {@code "unknown"}. */
     private String serverVersion = "unknown";
 
+    /** Creates a config with default server name and version. */
     public McpServerConfig() {}
 
+    /**
+     * Creates a config with the specified server name and version.
+     *
+     * @param serverName the server name
+     * @param serverVersion the server version
+     */
     public McpServerConfig(String serverName, String serverVersion) {
         this.serverName = serverName;
         this.serverVersion = serverVersion;
     }
 
+    /**
+     * Returns a new builder for constructing an {@link McpServerConfig}.
+     *
+     * @return a new builder instance
+     */
     public static McpServerConfigBuilder builder() {
         return new McpServerConfigBuilder();
     }
 
+    /**
+     * Returns the server name.
+     *
+     * @return the server name
+     */
     public String getServerName() {
         return serverName;
     }
 
+    /**
+     * Sets the server name.
+     *
+     * @param serverName the server name
+     */
     public void setServerName(String serverName) {
         this.serverName = serverName;
     }
 
+    /**
+     * Returns the server version.
+     *
+     * @return the server version
+     */
     public String getServerVersion() {
         return serverVersion;
     }
 
+    /**
+     * Sets the server version.
+     *
+     * @param serverVersion the server version
+     */
     public void setServerVersion(String serverVersion) {
         this.serverVersion = serverVersion;
     }
 
+    /** Builder for constructing {@link McpServerConfig} instances. */
     public static class McpServerConfigBuilder {
 
         private String serverName = "langchain4j-cdi";
         private String serverVersion = "unknown";
 
+        /** Creates a new builder with default values. */
+        public McpServerConfigBuilder() {}
+
+        /**
+         * Sets the server name.
+         *
+         * @param serverName the server name
+         * @return this builder
+         */
         public McpServerConfigBuilder serverName(String serverName) {
             this.serverName = serverName;
             return this;
         }
 
+        /**
+         * Sets the server version.
+         *
+         * @param serverVersion the server version
+         * @return this builder
+         */
         public McpServerConfigBuilder serverVersion(String serverVersion) {
             this.serverVersion = serverVersion;
             return this;
         }
 
+        /**
+         * Builds the {@link McpServerConfig}.
+         *
+         * @return the constructed config
+         */
         public McpServerConfig build() {
             return new McpServerConfig(serverName, serverVersion);
         }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpServerRequestManager.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpServerRequestManager.java
@@ -28,6 +28,9 @@ public class McpServerRequestManager {
     @Inject
     McpNotificationBroadcaster broadcaster;
 
+    /** CDI-required default constructor. */
+    public McpServerRequestManager() {}
+
     /**
      * Sends a JSON-RPC request to a specific client session and waits for the response.
      *
@@ -88,7 +91,13 @@ public class McpServerRequestManager {
         return false;
     }
 
-    /** Called when a JSON-RPC error response is received from a client. */
+    /**
+     * Called when a JSON-RPC error response is received from a client.
+     *
+     * @param id the response id
+     * @param errorMessage the error message from the client
+     * @return true if the error was matched to a pending request
+     */
     public boolean handleErrorResponse(Object id, String errorMessage) {
         if (id == null) {
             return false;
@@ -102,6 +111,11 @@ public class McpServerRequestManager {
         return false;
     }
 
+    /**
+     * Returns the number of requests currently awaiting a response.
+     *
+     * @return the count of pending requests
+     */
     public int pendingRequestCount() {
         return pendingRequests.size();
     }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpSession.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpSession.java
@@ -3,6 +3,10 @@ package dev.langchain4j.cdi.mcp.server.transport;
 import jakarta.json.JsonObject;
 import java.time.Instant;
 
+/**
+ * Represents an active MCP client session, tracking its identity, capabilities, initialization state, and last access
+ * time.
+ */
 public class McpSession {
 
     private final String id;
@@ -11,6 +15,12 @@ public class McpSession {
     private volatile boolean initialized;
     private volatile Instant lastAccessedAt;
 
+    /**
+     * Creates a new session with the given id and client capabilities.
+     *
+     * @param id the unique session identifier
+     * @param clientCapabilities the capabilities declared by the client during initialization
+     */
     public McpSession(String id, JsonObject clientCapabilities) {
         this.id = id;
         this.createdAt = Instant.now();
@@ -19,36 +29,68 @@ public class McpSession {
         this.initialized = false;
     }
 
+    /**
+     * Returns the unique session identifier.
+     *
+     * @return the session id
+     */
     public String getId() {
         return id;
     }
 
+    /**
+     * Returns the instant when this session was created.
+     *
+     * @return the creation timestamp
+     */
     public Instant getCreatedAt() {
         return createdAt;
     }
 
+    /**
+     * Returns the instant when this session was last accessed.
+     *
+     * @return the last access timestamp
+     */
     public Instant getLastAccessedAt() {
         return lastAccessedAt;
     }
 
+    /**
+     * Returns the client capabilities declared during initialization.
+     *
+     * @return the client capabilities as a JsonObject, or null if none were provided
+     */
     public JsonObject getClientCapabilities() {
         return clientCapabilities;
     }
 
+    /**
+     * Returns whether this session has completed the MCP initialization handshake.
+     *
+     * @return true if initialized
+     */
     public boolean isInitialized() {
         return initialized;
     }
 
+    /** Marks this session as initialized and updates the last access time. */
     public void markInitialized() {
         this.initialized = true;
         touch();
     }
 
+    /** Updates the last access timestamp to the current time. */
     public void touch() {
         this.lastAccessedAt = Instant.now();
     }
 
-    /** Checks if the client declared a given capability during initialization. */
+    /**
+     * Checks if the client declared a given capability during initialization.
+     *
+     * @param name the capability name
+     * @return {@code true} if the client declared the capability
+     */
     public boolean hasCapability(String name) {
         if (clientCapabilities == null) {
             return false;

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpSessionManager.java
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-server/src/main/java/dev/langchain4j/cdi/mcp/server/transport/McpSessionManager.java
@@ -14,6 +14,10 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+/**
+ * Manages the lifecycle of MCP sessions including creation, validation, termination, and automatic expiry of idle
+ * sessions.
+ */
 @ApplicationScoped
 public class McpSessionManager {
 
@@ -31,10 +35,16 @@ public class McpSessionManager {
     @Inject
     McpRootsManager rootsManager;
 
+    /** CDI-required default constructor. Uses the default 30-minute session timeout. */
     public McpSessionManager() {
         this(DEFAULT_SESSION_TIMEOUT);
     }
 
+    /**
+     * Creates a session manager with a custom session timeout.
+     *
+     * @param sessionTimeout the duration after which idle sessions are expired
+     */
     public McpSessionManager(Duration sessionTimeout) {
         this.sessionTimeout = sessionTimeout;
         this.cleanupExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
@@ -51,12 +61,26 @@ public class McpSessionManager {
         cleanupExecutor.shutdownNow();
     }
 
+    /**
+     * Creates a new session with a random UUID and stores it.
+     *
+     * @param initParams the client capabilities from the initialization request
+     * @return the new session identifier
+     */
     public String createSession(JsonObject initParams) {
         String id = UUID.randomUUID().toString();
         sessions.put(id, new McpSession(id, initParams));
         return id;
     }
 
+    /**
+     * Retrieves and touches the session, or throws if the session is invalid or missing.
+     *
+     * @param requestId the JSON-RPC request id (used in the exception if thrown)
+     * @param sessionId the session identifier from the {@code Mcp-Session-Id} header
+     * @return the validated session
+     * @throws McpSessionException if the session does not exist
+     */
     public McpSession requireSession(Object requestId, String sessionId) {
         if (sessionId == null || !sessions.containsKey(sessionId)) {
             throw new McpSessionException(requestId, "Invalid or missing Mcp-Session-Id");
@@ -66,6 +90,11 @@ public class McpSessionManager {
         return session;
     }
 
+    /**
+     * Terminates and removes a session, cleaning up associated subscriptions and roots.
+     *
+     * @param sessionId the session identifier to terminate
+     */
     public void terminateSession(String sessionId) {
         McpSession removed = sessions.remove(sessionId);
         if (removed != null) {
@@ -75,6 +104,11 @@ public class McpSessionManager {
         }
     }
 
+    /**
+     * Returns the number of currently active sessions.
+     *
+     * @return the active session count
+     */
     public int activeSessionCount() {
         return sessions.size();
     }

--- a/langchain4j-cdi-mp/langchain4j-cdi-config/src/main/java/dev/langchain4j/cdi/core/mpconfig/DurationConverter.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-config/src/main/java/dev/langchain4j/cdi/core/mpconfig/DurationConverter.java
@@ -1,14 +1,22 @@
-/** */
+/** MicroProfile Config integration for LangChain4j CDI. */
 package dev.langchain4j.cdi.core.mpconfig;
 
 import java.time.Duration;
 import org.eclipse.microprofile.config.spi.Converter;
 
 /**
+ * MicroProfile Config converter that parses duration strings into {@link Duration} instances.
+ *
+ * <p>Accepts ISO-8601 duration format (e.g. {@code PT30S}, {@code PT5M}) as well as shorthand notation without the
+ * {@code PT} prefix (e.g. {@code 30S}, {@code 5M}).
+ *
  * @author Buhake Sindi
  * @since 09 July 2025
  */
 public class DurationConverter implements Converter<Duration> {
+
+    /** Creates a new {@code DurationConverter}. */
+    public DurationConverter() {}
 
     @Override
     public Duration convert(String value) throws IllegalArgumentException, NullPointerException {

--- a/langchain4j-cdi-mp/langchain4j-cdi-config/src/main/java/dev/langchain4j/cdi/core/mpconfig/LLMConfigMPConfig.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-config/src/main/java/dev/langchain4j/cdi/core/mpconfig/LLMConfigMPConfig.java
@@ -10,7 +10,16 @@ import java.util.stream.StreamSupport;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 
+/**
+ * {@link LLMConfig} implementation backed by MicroProfile Config.
+ *
+ * <p>Reads LangChain4j plugin configuration properties from the MicroProfile Config subsystem, filtering on the
+ * standard {@value LLMConfig#PREFIX} prefix.
+ */
 public class LLMConfigMPConfig extends LLMConfig {
+
+    /** Creates a new {@code LLMConfigMPConfig}. */
+    public LLMConfigMPConfig() {}
 
     private Config config;
 

--- a/langchain4j-cdi-mp/langchain4j-cdi-config/src/main/java/dev/langchain4j/cdi/core/mpconfig/MpConfigExpressionResolver.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-config/src/main/java/dev/langchain4j/cdi/core/mpconfig/MpConfigExpressionResolver.java
@@ -28,6 +28,9 @@ import org.eclipse.microprofile.config.ConfigProvider;
  */
 public class MpConfigExpressionResolver implements ExpressionResolver {
 
+    /** Creates a new {@code MpConfigExpressionResolver}. */
+    public MpConfigExpressionResolver() {}
+
     private static final Logger LOGGER = Logger.getLogger(MpConfigExpressionResolver.class.getName());
     private static final Pattern MP_CONFIG_PATTERN = Pattern.compile("^\\$\\{(.+)\\}$");
 

--- a/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/main/java/dev/langchain4j/cdi/faulttolerance/spi/Langchain4JFaultToleranceExtension.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-fault-tolerance/src/main/java/dev/langchain4j/cdi/faulttolerance/spi/Langchain4JFaultToleranceExtension.java
@@ -33,10 +33,15 @@ import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
 /**
+ * CDI portable extension that applies MicroProfile Fault Tolerance interceptor bindings to AI service synthetic beans.
+ *
  * @author Buhake Sindi
  * @since 29 November 2024
  */
 public class Langchain4JFaultToleranceExtension implements Extension {
+
+    /** Creates a new {@code Langchain4JFaultToleranceExtension}. */
+    public Langchain4JFaultToleranceExtension() {}
 
     private static final Logger LOGGER = Logger.getLogger(Langchain4JFaultToleranceExtension.class.getName());
 

--- a/langchain4j-cdi-mp/langchain4j-cdi-telemetry/src/main/java/dev/langchain4j/cdi/telemetry/GenAIOperations.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-telemetry/src/main/java/dev/langchain4j/cdi/telemetry/GenAIOperations.java
@@ -10,37 +10,60 @@ package dev.langchain4j.cdi.telemetry;
  * @since 21 June 2026
  */
 public enum GenAIOperations {
+    /** Chat completion operation such as OpenAI Chat API. */
     CHAT("chat", "Chat completion operation such as OpenAI Chat API"),
+    /** Create a GenAI agent. */
     CREATE_AGENT("create_agent", "Create GenAI agent"),
+    /** Create new memory records. */
     CREATE_MEMORY("create_memory", "Create new memory records"),
+    /** Create or initialize a memory store. */
     CREATE_MEMORY_STORE("create_memory_store", "Create or initialize a memory store"),
+    /** Delete memory records. */
     DELETE_MEMORY("delete_memory", "Delete memory records"),
+    /** Delete or deprovision a memory store. */
     DELETE_MEMORY_STORE("delete_memory_store", "Delete or deprovision a memory store"),
+    /** Embeddings operation such as OpenAI Create embeddings API. */
     EMBEDDINGS("embeddings", "Embeddings operation such as OpenAI Create embeddings API"),
+    /** Execute a tool. */
     EXECUTE_TOOL("execute_tool", "Execute a tool"),
+    /** Multimodal content generation operation such as Gemini Generate Content. */
     GENERATE_CONTENT("generate_content", "Multimodal content generation operation such as Gemini Generate Content"),
+    /** Invoke a GenAI agent. */
     INVOKE_AGENT("invoke_agent", "Invoke GenAI agent"),
+    /** Invoke a GenAI workflow. */
     INVOKE_WORKFLOW("invoke_workflow", "Invoke GenAI workflow"),
+    /** Agent planning or task decomposition phase. */
     PLAN("plan", "Agent planning or task decomposition phase"),
+    /** Retrieval operation such as OpenAI Search Vector Store API. */
     RETRIEVAL("retrieval", "Retrieval operation such as OpenAI Search Vector Store API"),
+    /** Search or query memories from a memory store. */
     SEARCH_MEMORY("search_memory", "Search/query memories from a memory store"),
+    /** Text completions operation such as OpenAI Completions API (Legacy). */
     TEXT_COMPLETION("text_completion", "Text completions operation such as OpenAI Completions API (Legacy)"),
+    /** Update existing memory records. */
     UPDATE_MEMORY("update_memory", "Update existing memory records"),
+    /** Create or update memory records without the caller choosing which. */
     UPSERT_MEMORY("upsert_memory", "Create or update memory records without the caller choosing which");
 
     private final String operationName;
     private final String description;
 
     /**
-     * @param operationName
-     * @param description
+     * Creates a GenAI operation constant.
+     *
+     * @param operationName the OpenTelemetry operation name
+     * @param description a human-readable description of the operation
      */
     private GenAIOperations(final String operationName, final String description) {
         this.operationName = operationName;
         this.description = description;
     }
 
-    /** @return the description */
+    /**
+     * Returns the human-readable description of this operation.
+     *
+     * @return the description
+     */
     public String getDescription() {
         return description;
     }

--- a/langchain4j-cdi-mp/langchain4j-cdi-telemetry/src/main/java/dev/langchain4j/cdi/telemetry/GenAITracingTelemetry.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-telemetry/src/main/java/dev/langchain4j/cdi/telemetry/GenAITracingTelemetry.java
@@ -25,10 +25,15 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
+ * Base class providing OpenTelemetry span attribute population for GenAI semantic conventions.
+ *
  * @author Buhake Sindi
  * @since 25 June 2026
  */
 public abstract class GenAITracingTelemetry {
+
+    /** Creates a new instance. */
+    protected GenAITracingTelemetry() {}
 
     private static final Map<ModelProvider, String> GEN_AI_PROVIDERS;
 
@@ -53,10 +58,22 @@ public abstract class GenAITracingTelemetry {
 
     private final Logger LOGGER = Logger.getLogger(this.getClass().getName());
 
+    /**
+     * Sets the {@code gen_ai.provider.name} span attribute from the given model provider.
+     *
+     * @param span the span to populate
+     * @param provider the model provider
+     */
     protected void traceModelProvider(final Span span, final ModelProvider provider) {
         span.setAttribute("gen_ai.provider.name", GEN_AI_PROVIDERS.get(provider));
     }
 
+    /**
+     * Populates the span with GenAI request attributes from the given chat request.
+     *
+     * @param span the span to populate
+     * @param request the chat request containing model parameters and messages
+     */
     protected void traceChatRequest(final Span span, final ChatRequest request) {
         final List<ChatMessage> inputMessages = new ArrayList<>();
         final List<ChatMessage> systemInstructions = new ArrayList<>();
@@ -138,6 +155,12 @@ public abstract class GenAITracingTelemetry {
         }
     }
 
+    /**
+     * Populates the span with GenAI response attributes from the given chat response.
+     *
+     * @param span the span to populate
+     * @param response the chat response containing metadata and token usage
+     */
     protected void traceChatResponse(final Span span, final ChatResponse response) {
         span.setAttribute("gen_ai.response.id", response.metadata().id())
                 .setAttribute("gen_ai.response.model", response.metadata().modelName());
@@ -158,6 +181,12 @@ public abstract class GenAITracingTelemetry {
         }
     }
 
+    /**
+     * Records the given exception on the span.
+     *
+     * @param span the span to record the exception on
+     * @param exception the exception to record
+     */
     protected void traceException(final Span span, final Throwable exception) {
         span.recordException(exception);
     }

--- a/langchain4j-cdi-mp/langchain4j-cdi-telemetry/src/main/java/dev/langchain4j/cdi/telemetry/MetricsChatModelListener.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-telemetry/src/main/java/dev/langchain4j/cdi/telemetry/MetricsChatModelListener.java
@@ -27,6 +27,9 @@ import java.util.concurrent.TimeUnit;
 @Dependent
 public class MetricsChatModelListener implements ChatModelListener {
 
+    /** Creates a new instance. */
+    public MetricsChatModelListener() {}
+
     private static final String MP_AI_METRIC_START_TIME_NAME = "MP_AI_METRIC_START_TIME";
 
     private static final String METRIC_CLIENT_TOKEN_USAGE_NAME = "gen_ai.client.token.usage";

--- a/langchain4j-cdi-mp/langchain4j-cdi-telemetry/src/main/java/dev/langchain4j/cdi/telemetry/SpanAgentListener.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-telemetry/src/main/java/dev/langchain4j/cdi/telemetry/SpanAgentListener.java
@@ -25,6 +25,9 @@ import jakarta.inject.Inject;
 @Dependent
 public class SpanAgentListener extends GenAITracingTelemetry implements AgentListener {
 
+    /** Creates a new instance. */
+    public SpanAgentListener() {}
+
     private static final GenAIOperations OPERATION_INVOKE_AGENT = GenAIOperations.INVOKE_AGENT;
 
     @Inject

--- a/langchain4j-cdi-mp/langchain4j-cdi-telemetry/src/main/java/dev/langchain4j/cdi/telemetry/SpanChatModelListener.java
+++ b/langchain4j-cdi-mp/langchain4j-cdi-telemetry/src/main/java/dev/langchain4j/cdi/telemetry/SpanChatModelListener.java
@@ -23,6 +23,9 @@ import jakarta.inject.Inject;
 @Dependent
 public class SpanChatModelListener extends GenAITracingTelemetry implements ChatModelListener {
 
+    /** Creates a new SpanChatModelListener. */
+    public SpanChatModelListener() {}
+
     private static final String OTEL_SCOPE_KEY_NAME = "OTelScope";
     private static final String OTEL_SPAN_KEY_NAME = "OTelSpan";
     private static final GenAIOperations GEN_AI_OPERATION = GenAIOperations.CHAT;

--- a/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/InterceptorBeanAttributes.java
+++ b/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/InterceptorBeanAttributes.java
@@ -1,4 +1,3 @@
-/** */
 package dev.langchain4j.cdi.core.portableextension;
 
 import jakarta.enterprise.inject.spi.BeanAttributes;
@@ -6,15 +5,18 @@ import java.lang.annotation.Annotation;
 import java.util.Set;
 
 /**
+ * Extended {@link BeanAttributes} that exposes interceptor binding annotations for a bean.
+ *
+ * @param <T> the bean type
  * @author Buhake Sindi
  * @since 26 June 2026
  */
 public interface InterceptorBeanAttributes<T> extends BeanAttributes<T> {
 
     /**
-     * Obtains the {@linkplain jakarta.interceptor.InterceptorBinding interceptorBindings} of the bean.
+     * Obtains the {@code InterceptorBinding} annotations of the bean.
      *
-     * @return the {@linkplain jakarta.interceptor.InterceptorBinding interceptorBindings}
+     * @return the interceptor bindings
      */
     public Set<Annotation> getInterceptorBindings();
 }

--- a/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/LangChain4JAIAgentBean.java
+++ b/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/LangChain4JAIAgentBean.java
@@ -24,6 +24,12 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * CDI {@link Bean} implementation that creates agent proxies for interfaces annotated with one of the agent topology
+ * stereotypes (e.g. {@code @RegisterSimpleAgent}, {@code @RegisterSequenceAgent}).
+ *
+ * @param <T> the agent interface type
+ */
 public class LangChain4JAIAgentBean<T> implements Bean<T>, InterceptorBeanAttributes<T>, PassivationCapable {
 
     private final Class<T> agentInterfaceClass;
@@ -33,6 +39,12 @@ public class LangChain4JAIAgentBean<T> implements Bean<T>, InterceptorBeanAttrib
     private final Class<? extends Annotation> stereotypeAnnotationClass;
     private Set<Annotation> interceptorBindings;
 
+    /**
+     * Creates a new bean definition for the given agent interface.
+     *
+     * @param agentInterfaceClass the interface annotated with an agent topology stereotype
+     * @param beanManager the CDI bean manager used for interception support
+     */
     public LangChain4JAIAgentBean(Class<T> agentInterfaceClass, BeanManager beanManager) {
         super();
         this.agentInterfaceClass = agentInterfaceClass;

--- a/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/LangChain4JAIServiceBean.java
+++ b/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/LangChain4JAIServiceBean.java
@@ -19,6 +19,10 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
+ * CDI {@link Bean} implementation that creates AI service proxies for interfaces annotated with
+ * {@link RegisterAIService}.
+ *
+ * @param <T> the AI service interface type
  * @author Buhake Sindi
  * @since 21 November 2024
  */
@@ -33,8 +37,10 @@ public class LangChain4JAIServiceBean<T> implements Bean<T>, InterceptorBeanAttr
     private Set<Annotation> interceptorBindings;
 
     /**
-     * @param aiServiceInterfaceClass
-     * @param beanManager
+     * Creates a new bean definition for the given AI service interface.
+     *
+     * @param aiServiceInterfaceClass the interface annotated with {@link RegisterAIService}
+     * @param beanManager the CDI bean manager used for interception support
      */
     public LangChain4JAIServiceBean(Class<T> aiServiceInterfaceClass, BeanManager beanManager) {
         super();

--- a/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/LangChain4JAIServicePortableExtension.java
+++ b/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/LangChain4JAIServicePortableExtension.java
@@ -30,15 +30,32 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Logger;
 
+/**
+ * CDI portable extension that discovers interfaces annotated with {@link RegisterAIService} and agent topology
+ * stereotypes, then registers synthetic beans for each at deployment time.
+ */
 public class LangChain4JAIServicePortableExtension implements Extension {
     private static final Logger LOGGER = Logger.getLogger(LangChain4JAIServicePortableExtension.class.getName());
     private static final Set<Class<?>> detectedAIServicesDeclaredInterfaces = new HashSet<>();
     private static final Set<Class<?>> detectedAgentDeclaredInterfaces = new HashSet<>();
 
+    /** Creates a new instance of this portable extension. */
+    public LangChain4JAIServicePortableExtension() {}
+
+    /**
+     * Returns the set of AI service interfaces detected during bean discovery.
+     *
+     * @return the detected AI service interfaces
+     */
     public static Set<Class<?>> getDetectedAIServicesDeclaredInterfaces() {
         return detectedAIServicesDeclaredInterfaces;
     }
 
+    /**
+     * Returns the set of agent interfaces detected during bean discovery.
+     *
+     * @return the detected agent interfaces
+     */
     public static Set<Class<?>> getDetectedAgentDeclaredInterfaces() {
         return detectedAgentDeclaredInterfaces;
     }

--- a/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/LangChain4JPluginsPortableExtension.java
+++ b/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/LangChain4JPluginsPortableExtension.java
@@ -12,8 +12,16 @@ import java.util.Arrays;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+/**
+ * CDI portable extension that creates beans from LLM configuration properties discovered via the
+ * {@link LLMConfigProvider} SPI.
+ */
 public class LangChain4JPluginsPortableExtension implements Extension {
     private static final Logger LOGGER = Logger.getLogger(LangChain4JPluginsPortableExtension.class.getName());
+
+    /** Creates a new instance of this portable extension. */
+    public LangChain4JPluginsPortableExtension() {}
+
     private LLMConfig llmConfig;
 
     void afterBeanDiscovery(@Observes AfterBeanDiscovery afterBeanDiscovery, BeanManager beanManager)

--- a/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/Reflections.java
+++ b/langchain4j-cdi-portable-ext/src/main/java/dev/langchain4j/cdi/core/portableextension/Reflections.java
@@ -8,6 +8,8 @@ import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 
 /**
+ * Utility methods for extracting raw {@link Class} instances from generic {@link Type} objects.
+ *
  * @author Buhake Sindi
  * @since 03 December 2015
  */
@@ -17,6 +19,14 @@ public final class Reflections {
         throw new AssertionError("Private Constructor.");
     }
 
+    /**
+     * Returns the raw {@link Class} for the given {@link Type}, unwrapping parameterized types, type variables,
+     * wildcard types, and generic array types as necessary.
+     *
+     * @param <T> the expected raw type
+     * @param type the type to extract the raw class from
+     * @return the raw class, or {@code null} if the type cannot be resolved
+     */
     @SuppressWarnings("unchecked")
     public static <T> Class<T> getRawType(Type type) {
         if (type instanceof Class<?>) {


### PR DESCRIPTION
Eliminate 2 javadoc errors and 910 warnings across 226 files in all modules. Only 2 unavoidable warnings remain from upstream LangChain4j enum constants (SupervisorContextStrategy, SupervisorResponseStrategy).

- core: add @param/@return to CdiLookupHelper, CommonAIServiceCreator, CommonAgentCreator, AgentAnnotationMeta, LLMConfig, CommonLLMPluginCreator; add javadoc to all 12 Register*Agent annotation attributes
- mcp-server: add javadoc to all 46 files across api, error, logging, protocol, registry, schema, and transport packages
- extensions: add javadoc to portable-ext, build-compatible-ext, a2a, el
- mp: add javadoc to telemetry, config, fault-tolerance modules
- integration-tests: add javadoc to all test helper classes
- examples: add javadoc to all 9 car-booking example modules
- fix InterceptorBeanAttributes unresolvable {@linkplain} reference