### PR TITLE
refactor(build-compatible-ext): resolve JPMS split packages

### DIFF
--- a/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/core/buildcompatibleextension/AIAgentCreator.java
+++ b/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/core/buildcompatibleextension/AIAgentCreator.java
@@ -1,4 +1,4 @@
-package dev.langchain4j.cdi.aiservice;
+package dev.langchain4j.cdi.core.buildcompatibleextension;
 
 import dev.langchain4j.cdi.agent.CommonAgentCreator;
 import jakarta.enterprise.inject.Instance;

--- a/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/core/buildcompatibleextension/AIServiceCreator.java
+++ b/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/core/buildcompatibleextension/AIServiceCreator.java
@@ -1,5 +1,6 @@
-package dev.langchain4j.cdi.aiservice;
+package dev.langchain4j.cdi.core.buildcompatibleextension;
 
+import dev.langchain4j.cdi.aiservice.CommonAIServiceCreator;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.build.compatible.spi.Parameters;
 import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;

--- a/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/core/buildcompatibleextension/AISyntheticBeanCreatorClassFactory.java
+++ b/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/core/buildcompatibleextension/AISyntheticBeanCreatorClassFactory.java
@@ -2,7 +2,7 @@
  *  Copyright The WildFly Authors
  *  SPDX-License-Identifier: Apache-2.0
  */
-package dev.langchain4j.cdi.spi;
+package dev.langchain4j.cdi.core.buildcompatibleextension;
 
 import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
 

--- a/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/core/buildcompatibleextension/AISyntheticBeanCreatorClassProvider.java
+++ b/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/core/buildcompatibleextension/AISyntheticBeanCreatorClassProvider.java
@@ -2,7 +2,7 @@
  *  Copyright The WildFly Authors
  *  SPDX-License-Identifier: Apache-2.0
  */
-package dev.langchain4j.cdi.spi;
+package dev.langchain4j.cdi.core.buildcompatibleextension;
 
 import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
 import java.util.ArrayList;
@@ -34,7 +34,7 @@ public class AISyntheticBeanCreatorClassProvider {
                     try {
                         return (Class<? extends SyntheticBeanCreator<Object>>) Thread.currentThread()
                                 .getContextClassLoader()
-                                .loadClass("dev.langchain4j.cdi.plugin.LLMPluginCreator");
+                                .loadClass("dev.langchain4j.cdi.core.buildcompatibleextension.LLMPluginCreator");
                     } catch (ClassNotFoundException ex) {
                         throw new RuntimeException(ex);
                     }

--- a/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/core/buildcompatibleextension/LLMPluginCreator.java
+++ b/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/core/buildcompatibleextension/LLMPluginCreator.java
@@ -1,6 +1,7 @@
-package dev.langchain4j.cdi.plugin;
+package dev.langchain4j.cdi.core.buildcompatibleextension;
 
 import dev.langchain4j.cdi.core.config.spi.LLMConfigProvider;
+import dev.langchain4j.cdi.plugin.CommonLLMPluginCreator;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.build.compatible.spi.Parameters;
 import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;

--- a/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/core/buildcompatibleextension/LangChain4JPluginsBuildCompatibleExtension.java
+++ b/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/core/buildcompatibleextension/LangChain4JPluginsBuildCompatibleExtension.java
@@ -1,8 +1,8 @@
-package dev.langchain4j.cdi.plugin;
+package dev.langchain4j.cdi.core.buildcompatibleextension;
 
 import dev.langchain4j.cdi.core.config.spi.LLMConfig;
 import dev.langchain4j.cdi.core.config.spi.LLMConfigProvider;
-import dev.langchain4j.cdi.spi.AISyntheticBeanCreatorClassProvider;
+import dev.langchain4j.cdi.plugin.CommonLLMPluginCreator;
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
 import jakarta.enterprise.inject.build.compatible.spi.Synthesis;
 import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanBuilder;

--- a/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/core/buildcompatibleextension/Langchain4JAIServiceBuildCompatibleExtension.java
+++ b/langchain4j-cdi-build-compatible-ext/src/main/java/dev/langchain4j/cdi/core/buildcompatibleextension/Langchain4JAIServiceBuildCompatibleExtension.java
@@ -1,10 +1,11 @@
-package dev.langchain4j.cdi.aiservice;
+package dev.langchain4j.cdi.core.buildcompatibleextension;
 
 import dev.langchain4j.agentic.internal.AgenticScopeOwner;
 import dev.langchain4j.agentic.internal.InternalAgent;
 import dev.langchain4j.agentic.scope.AgenticScopeAccess;
 import dev.langchain4j.cdi.agent.AgentAnnotationMeta;
 import dev.langchain4j.cdi.agent.CommonAgentCreator;
+import dev.langchain4j.cdi.aiservice.CdiLookupHelper;
 import dev.langchain4j.cdi.spi.RegisterA2AAgent;
 import dev.langchain4j.cdi.spi.RegisterAIService;
 import dev.langchain4j.cdi.spi.RegisterConditionalAgent;

--- a/langchain4j-cdi-build-compatible-ext/src/main/resources/META-INF/services/jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension
+++ b/langchain4j-cdi-build-compatible-ext/src/main/resources/META-INF/services/jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension
@@ -1,2 +1,2 @@
-dev.langchain4j.cdi.aiservice.Langchain4JAIServiceBuildCompatibleExtension
-dev.langchain4j.cdi.plugin.LangChain4JPluginsBuildCompatibleExtension
+dev.langchain4j.cdi.core.buildcompatibleextension.Langchain4JAIServiceBuildCompatibleExtension
+dev.langchain4j.cdi.core.buildcompatibleextension.LangChain4JPluginsBuildCompatibleExtension

--- a/langchain4j-cdi-build-compatible-ext/src/test/java/dev/langchain4j/cdi/core/BceAgentExtensionTest.java
+++ b/langchain4j-cdi-build-compatible-ext/src/test/java/dev/langchain4j/cdi/core/BceAgentExtensionTest.java
@@ -2,7 +2,7 @@ package dev.langchain4j.cdi.core;
 
 import dev.langchain4j.agentic.internal.InternalAgent;
 import dev.langchain4j.cdi.agent.CommonAgentCreator;
-import dev.langchain4j.cdi.aiservice.Langchain4JAIServiceBuildCompatibleExtension;
+import dev.langchain4j.cdi.core.buildcompatibleextension.Langchain4JAIServiceBuildCompatibleExtension;
 import io.smallrye.config.inject.ConfigExtension;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.spi.Bean;

--- a/langchain4j-cdi-build-compatible-ext/src/test/java/dev/langchain4j/cdi/core/BceExtensionTest.java
+++ b/langchain4j-cdi-build-compatible-ext/src/test/java/dev/langchain4j/cdi/core/BceExtensionTest.java
@@ -1,6 +1,6 @@
 package dev.langchain4j.cdi.core;
 
-import dev.langchain4j.cdi.aiservice.Langchain4JAIServiceBuildCompatibleExtension;
+import dev.langchain4j.cdi.core.buildcompatibleextension.Langchain4JAIServiceBuildCompatibleExtension;
 import dev.langchain4j.model.chat.ChatModel;
 import io.smallrye.config.inject.ConfigExtension;
 import jakarta.enterprise.context.ApplicationScoped;


### PR DESCRIPTION
Move classes from dev.langchain4j.cdi.aiservice, .plugin, and .spi into dev.langchain4j.cdi.core.buildcompatibleextension to eliminate split package violations between langchain4j-cdi-core and langchain4j-cdi-build-compatible-ext. Updates META-INF/services registrations and test imports accordingly.