### PR TITLE
chore(deps): upgrade LangChain4j to 1.18.0

### DIFF
--- a/docs/content/index.html
+++ b/docs/content/index.html
@@ -96,7 +96,7 @@ layout: home
       </tr>
       <tr>
         <td>dev (unreleased)</td>
-        <td>1.17.1</td>
+        <td>1.18.0</td>
         <td>17+</td>
         <td>10</td>
         <td>6.1</td>

--- a/pom.xml
+++ b/pom.xml
@@ -68,9 +68,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.outputTimestamp>2026-06-30T10:56:39Z</project.build.outputTimestamp>
 
-        <dev.langchain4j.version>1.17.1</dev.langchain4j.version>
-        <dev.langchain4j.agentic.version>1.17.1-beta27</dev.langchain4j.agentic.version>
-        <dev.langchain4j.community.version>1.17.1-beta27</dev.langchain4j.community.version>
+        <dev.langchain4j.version>1.18.0</dev.langchain4j.version>
+        <dev.langchain4j.agentic.version>1.18.0-beta28</dev.langchain4j.agentic.version>
+        <dev.langchain4j.community.version>1.18.0-beta28</dev.langchain4j.community.version>
         <jakartaee-api.version>10.0.0</jakartaee-api.version>
         <jakarta.enterprise.cdi-api.version>4.0.1</jakarta.enterprise.cdi-api.version>
         <org.mcp-java.version>1.0.0-Beta1</org.mcp-java.version>


### PR DESCRIPTION
Update LangChain4j dependencies:
- langchain4j: 1.17.1 → 1.18.0
- langchain4j-agentic: 1.17.1-beta27 → 1.18.0-beta28
- langchain4j-community: 1.17.1-beta27 → 1.18.0-beta28