### PR TITLE
Update to the LangChain4J-CDI documentations.

### DIFF
--- a/docs/content/examples.md
+++ b/docs/content/examples.md
@@ -81,3 +81,4 @@ Hands-on workshops to learn LangChain4j CDI step by step:
 |----------|-------------|
 | [Liberty LangChain4j Workshop](https://github.com/OpenLiberty/liberty-workshop-langchain4j) | Open Liberty workshop for building AI-powered applications with LangChain4j |
 | [LangChain4j CDI Lab 2026](https://github.com/ehsavoie/langchain4j-cdi-lab-2026) | Practical lab exercises covering LangChain4j CDI integration |
+| [LangChain4j CDI Lab 2026 (JCON Slovenia)](https://github.com/TheEliteGentleman/langchain4j-cdi-lab-jcon-slovenia-2026) | Practical lab exercises covering LangChain4j CDI integration (for JCON Slovenia 2026) |

--- a/docs/content/fault-tolerance.md
+++ b/docs/content/fault-tolerance.md
@@ -31,6 +31,10 @@ public interface ChatBot {
 }
 ```
 
+*Note*: LangChain4J has a built-in resiliency in its service. It's retry policy (enabled by default) is set to `maxRetries = 2`. 
+So, should you include Microprofile `@Retry` policy, disable LangChain4J's `ChatModel`'s `maxRetries` by setting it to 0 so that you won't experience the `MxN` execution problem.
+
+
 ## Timeout
 
 Set a maximum duration for AI calls:


### PR DESCRIPTION
Update to the LangChain4J-CDI documentation, this time with more workshop links and a caveat on using the Retry policy on LangChain4J.