### PR TITLE
fix(core): downgrade NoSuchMethodException logs from WARNING/SEVERE to FINE

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip

--- a/docs/content/ai-services.md
+++ b/docs/content/ai-services.md
@@ -83,8 +83,8 @@ Guardrails validate messages before they are sent to the model (input) or before
 
 ```java
 @RegisterAIService(
-    inputGuardrails = {NoEmptyMessageGuardrail.class},
-    outputGuardrails = {ContentFilterGuardrail.class}
+    inputGuardrails = \{NoEmptyMessageGuardrail.class},
+    outputGuardrails = \{ContentFilterGuardrail.class}
 )
 public interface SafeChatService {
     String chat(String userMessage);

--- a/docs/content/posts/2026-08-17-langchain4j-cdi-1.4.0/index.md
+++ b/docs/content/posts/2026-08-17-langchain4j-cdi-1.4.0/index.md
@@ -1,0 +1,61 @@
+---
+layout: post
+title: 'LangChain4j CDI 1.4.0 Released'
+date: 2026-08-17
+tags: release langchain4j cdi
+synopsis: 'LangChain4j CDI 1.4.0 ships thinking capture support, GenAI telemetry improvements, a full MCP Java 1.x migration, and LangChain4j 1.19.0.'
+author: ehsavoie
+---
+
+LangChain4j CDI 1.4.0 is available. This release brings thinking capture for AI services, improvements to GenAI telemetry semantics, a full migration to MCP Java 1.x, and a module-system fix for build-time extensions.
+
+## What's New
+
+### Thinking Capture for AI Services
+
+AI service methods can now capture the model's internal reasoning — the "thinking" tokens emitted by reasoning models like Claude. This is exposed via a new listener/guardrail hook, so you can observe or act on the thought chain alongside the final response.
+
+### GenAI Telemetry Improvements
+
+The `langchain4j-cdi-telemetry` module now follows the OpenTelemetry [GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) more completely, including correct exception semantics. If a model call raises an error, the resulting span is now attributed according to the GenAI spec rather than the generic HTTP conventions.
+
+### MCP Java 1.x Migration
+
+The MCP server module tree has been migrated to **MCP Java 1.x** (`mcpjava 1.x`). This is a breaking change within the MCP sub-tree: package names and some API surface were reorganised as part of the 1.x overhaul. If you depend on `langchain4j-cdi-mcp-*` directly, check the [MCP Server]({site.url('mcp-server')}) guide and the upstream MCP Java changelog for the new package names.
+
+### JPMS Split-Package Fix
+
+A split-package conflict in the build-compatible extension (`langchain4j-cdi-build-compatible-ext`) has been resolved. Applications running on runtimes that enforce Java module boundaries (JPMS) -- such as Quarkus with strict module mode -- will no longer encounter split-package errors at startup.
+
+## Dependency Upgrades
+
+| Dependency | From | To |
+|---|---|---|
+| LangChain4j | 1.18.0 | 1.19.0 |
+| `resteasy-bom` | 6.2.16.Final | 6.2.17.Final |
+| `yasson` | 3.0.4 | 3.0.5 |
+| `cargo-maven3-plugin` | 1.10.27 | 1.10.28 |
+| `apache-maven` | 3.9.11 | 3.9.16 |
+| `maven-wrapper` | 3.3.2 | 3.3.4 |
+
+## Upgrading
+
+Update your dependency version to `1.4.0`:
+
+```xml
+<properties>
+    <langchain4j-cdi.version>1.4.0</langchain4j-cdi.version>
+</properties>
+```
+
+If you use the MCP server module, review the [MCP Server]({site.url('mcp-server')}) documentation and verify your import statements after the mcpjava 1.x package rename.
+
+## Contributors
+
+Thank you to everyone who contributed to this release:
+
+- **@ehsavoie** -- thinking capture, MCP migration, JPMS fix, and release coordination
+- **@TheEliteGentleman** -- telemetry improvements and documentation
+- **@dependabot** -- automated dependency upgrades
+
+Full release notes and the complete list of merged pull requests are available on the [GitHub Releases page](https://github.com/langchain4j/langchain4j-cdi/releases/tag/1.4.0).

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/agent/CommonAgentCreator.java
@@ -726,12 +726,14 @@ public class CommonAgentCreator {
             TypedKey<?> instance = typedKeyClass.getDeclaredConstructor().newInstance();
             String name = instance.name();
             return hasText(name) ? name : typedKeyClass.getSimpleName();
+        } catch (NoSuchMethodException e) {
+            return typedKeyClass.getSimpleName();
         } catch (Exception e) {
             LOGGER.log(
                     Level.WARNING,
                     e,
                     () -> "Cannot instantiate TypedKey class " + typedKeyClass.getName()
-                            + " (no accessible no-arg constructor?), falling back to simple class name");
+                            + ", falling back to simple class name");
             return typedKeyClass.getSimpleName();
         }
     }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/aiservice/CdiLookupHelper.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/aiservice/CdiLookupHelper.java
@@ -103,8 +103,8 @@ public final class CdiLookupHelper {
 
     /**
      * Resolve guardrail instances by class. For each class, first attempts CDI lookup; if the bean is not resolvable,
-     * falls back to instantiation via the no-arg constructor. Classes that fail both resolution paths are skipped with
-     * a WARNING log.
+     * falls back to instantiation via the no-arg constructor. Classes without a no-arg constructor are skipped silently
+     * (FINE log). Other instantiation failures are skipped with a WARNING log.
      *
      * @param <G> the guardrail type
      * @param lookup the CDI {@link Instance} used for bean resolution
@@ -122,6 +122,12 @@ public final class CdiLookupHelper {
                     guardrails.add(
                             guardrailClass.getConstructor((Class<?>[]) null).newInstance((Object[]) null));
                 }
+            } catch (NoSuchMethodException ex) {
+                LOGGER.log(
+                        Level.FINE,
+                        ex,
+                        () -> "No public no-arg constructor for guardrail class " + guardrailClass
+                                + " and not resolvable as a CDI bean, skipping");
             } catch (ReflectiveOperationException | IllegalArgumentException ex) {
                 LOGGER.log(
                         Level.WARNING,
@@ -186,8 +192,8 @@ public final class CdiLookupHelper {
 
     /**
      * Resolve tool instances from an array of tool classes. For each class, first attempts CDI lookup; if the bean is
-     * not resolvable, falls back to instantiation via the no-arg constructor. Classes that fail both resolution paths
-     * are skipped with a SEVERE log.
+     * not resolvable, falls back to instantiation via the no-arg constructor. Classes without a no-arg constructor are
+     * skipped silently (FINE log). Other instantiation failures are skipped with a SEVERE log.
      *
      * @param toolClasses the tool classes to resolve or instantiate
      * @param lookup the CDI {@link Instance} used for bean resolution
@@ -203,6 +209,12 @@ public final class CdiLookupHelper {
                 } else {
                     tools.add(toolClass.getConstructor((Class<?>[]) null).newInstance((Object[]) null));
                 }
+            } catch (NoSuchMethodException ex) {
+                LOGGER.log(
+                        Level.FINE,
+                        ex,
+                        () -> "No public no-arg constructor for tool class " + toolClass
+                                + " and not resolvable as a CDI bean, skipping");
             } catch (ReflectiveOperationException | IllegalArgumentException ex) {
                 LOGGER.log(Level.SEVERE, "Failed to create tool " + toolClass + ", skipping: " + ex.getMessage(), ex);
             }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/aiservice/CommonAIServiceCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/aiservice/CommonAIServiceCreator.java
@@ -15,6 +15,7 @@ import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.service.AiServices;
 import dev.langchain4j.service.tool.ToolProvider;
 import jakarta.enterprise.inject.Instance;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.time.Instant;
@@ -182,6 +183,11 @@ public class CommonAIServiceCreator {
                         ctx != null ? ctx.chatMemoryId() : null,
                         Instant.now());
                 thinkingMethod.invoke(null, emitted);
+            } catch (InvocationTargetException e) {
+                LOGGER.log(
+                        Level.WARNING,
+                        "@OnThinking handler on " + interfaceClass.getSimpleName() + " failed: "
+                                + e.getCause().getMessage());
             } catch (Exception e) {
                 LOGGER.log(Level.WARNING, "@OnThinking handler on " + interfaceClass.getSimpleName() + " failed", e);
             }

--- a/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/CommonAgentCreatorTest.java
+++ b/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/agent/CommonAgentCreatorTest.java
@@ -1584,8 +1584,30 @@ class CommonAgentCreatorTest {
 
     @Test
     void resolveTypedKeyName_withNoDefaultConstructor_fallsBackToSimpleName() {
-        String result = CommonAgentCreator.resolveTypedKeyName(NoDefaultConstructorTypedKey.class);
-        assertEquals("NoDefaultConstructorTypedKey", result);
+        Logger logger = Logger.getLogger(CommonAgentCreator.class.getName());
+        List<LogRecord> records = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                records.add(record);
+            }
+
+            @Override
+            public void flush() {}
+
+            @Override
+            public void close() {}
+        };
+        logger.addHandler(handler);
+        try {
+            String result = CommonAgentCreator.resolveTypedKeyName(NoDefaultConstructorTypedKey.class);
+            assertEquals("NoDefaultConstructorTypedKey", result);
+            assertTrue(
+                    records.stream().noneMatch(r -> r.getLevel().intValue() >= Level.WARNING.intValue()),
+                    "No WARNING should be logged for a missing no-arg constructor — it is an expected fallback");
+        } finally {
+            logger.removeHandler(handler);
+        }
     }
 
     // =========================================================================

--- a/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/aiservice/CommonAIServiceCreatorTest.java
+++ b/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/aiservice/CommonAIServiceCreatorTest.java
@@ -25,7 +25,13 @@ import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.service.tool.ToolProvider;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.literal.NamedLiteral;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -400,9 +406,82 @@ class CommonAIServiceCreatorTest {
         when(lookup.select(UninstantiableGuardrail.class)).thenReturn(igInstance);
         when(igInstance.isResolvable()).thenReturn(false);
 
-        // Should not throw - guardrail is skipped with a warning
-        Object service = CommonAIServiceCreator.create(lookup, MyAIServiceWithUninstantiableGuardrail.class);
-        assertNotNull(service);
+        Logger logger = Logger.getLogger(CdiLookupHelper.class.getName());
+        List<LogRecord> records = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                records.add(record);
+            }
+
+            @Override
+            public void flush() {}
+
+            @Override
+            public void close() {}
+        };
+        logger.addHandler(handler);
+        try {
+            Object service = CommonAIServiceCreator.create(lookup, MyAIServiceWithUninstantiableGuardrail.class);
+            assertNotNull(service);
+            assertTrue(
+                    records.stream().noneMatch(r -> r.getLevel().intValue() >= Level.WARNING.intValue()),
+                    "No WARNING should be logged for a missing no-arg constructor — it is an expected fallback");
+        } finally {
+            logger.removeHandler(handler);
+        }
+    }
+
+    // --- Uninstantiable tool test ---
+
+    public static class UninstantiableTool {
+        public UninstantiableTool(String required) {}
+
+        @Tool
+        public String doWork() {
+            return "unreachable";
+        }
+    }
+
+    @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
+    @RegisterAIService(tools = {UninstantiableTool.class})
+    interface MyAIServiceWithUninstantiableTool {
+        String chat(String question);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void create_skipsToolWhenBothCdiAndConstructorFail() {
+        Instance<Object> lookup = prepareLookups();
+
+        Instance<UninstantiableTool> toolInstance = mock(Instance.class);
+        when(lookup.select(UninstantiableTool.class)).thenReturn(toolInstance);
+        when(toolInstance.isResolvable()).thenReturn(false);
+
+        Logger logger = Logger.getLogger(CdiLookupHelper.class.getName());
+        List<LogRecord> records = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                records.add(record);
+            }
+
+            @Override
+            public void flush() {}
+
+            @Override
+            public void close() {}
+        };
+        logger.addHandler(handler);
+        try {
+            Object service = CommonAIServiceCreator.create(lookup, MyAIServiceWithUninstantiableTool.class);
+            assertNotNull(service);
+            assertTrue(
+                    records.stream().noneMatch(r -> r.getLevel().intValue() >= Level.WARNING.intValue()),
+                    "No WARNING should be logged for a missing no-arg constructor — it is an expected fallback");
+        } finally {
+            logger.removeHandler(handler);
+        }
     }
 
     @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
@@ -638,11 +717,40 @@ class CommonAIServiceCreatorTest {
         when(cmInstance.get()).thenReturn(thinkingModel);
         when(lookup.select(ChatModel.class)).thenReturn(cmInstance);
 
-        ServiceWithThrowingOnThinking service =
-                CommonAIServiceCreator.create(lookup, ServiceWithThrowingOnThinking.class);
-        String result = service.chat("hello");
+        Logger logger = Logger.getLogger(CommonAIServiceCreator.class.getName());
+        List<LogRecord> records = new ArrayList<>();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                records.add(record);
+            }
 
-        assertNotNull(result);
-        assertTrue(THROWING_HANDLER_CALLED.get());
+            @Override
+            public void flush() {}
+
+            @Override
+            public void close() {}
+        };
+        logger.addHandler(handler);
+        try {
+            ServiceWithThrowingOnThinking service =
+                    CommonAIServiceCreator.create(lookup, ServiceWithThrowingOnThinking.class);
+            String result = service.chat("hello");
+
+            assertNotNull(result);
+            assertTrue(THROWING_HANDLER_CALLED.get());
+            assertEquals(
+                    1,
+                    records.stream().filter(r -> r.getLevel() == Level.WARNING).count(),
+                    "A single WARNING should be logged when the @OnThinking handler throws");
+            LogRecord warning = records.stream()
+                    .filter(r -> r.getLevel() == Level.WARNING)
+                    .findFirst()
+                    .orElseThrow();
+            assertTrue(warning.getMessage().contains("handler explosion"));
+            assertNull(warning.getThrown(), "Stack trace should not be attached for InvocationTargetException");
+        } finally {
+            logger.removeHandler(handler);
+        }
     }
 }

--- a/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-helidon/pom.xml
+++ b/langchain4j-cdi-mcp/langchain4j-cdi-mcp-integration-tests/langchain4j-cdi-mcp-integration-tests-helidon/pom.xml
@@ -21,6 +21,14 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Import langchain4j-bom first so its versions take precedence over Helidon's bundled langchain4j (1.6.0) -->
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-bom</artifactId>
+                <version>${dev.langchain4j.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.helidon</groupId>
                 <artifactId>helidon-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -417,7 +417,7 @@
             <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.10.0</version>
                 <configuration>
                     <java>
                         <palantirJavaFormat>
@@ -429,6 +429,7 @@
                     <pom>
                         <sortPom>
                             <nrOfIndentSpace>4</nrOfIndentSpace>
+                            <spaceBeforeCloseEmptyElement>false</spaceBeforeCloseEmptyElement>
                         </sortPom>
                     </pom>
                 </configuration>


### PR DESCRIPTION
Reflection-based fallbacks in resolveTypedKeyName, resolveGuardrailsByClass, and resolveToolInstances logged at WARNING/SEVERE when a class lacked a no-arg constructor — an expected code path, not an error. Catch NoSuchMethodException separately and log at FINE. Add log-level assertions to existing tests and a new test for the tool path.